### PR TITLE
feat: follow logs

### DIFF
--- a/src/containers/Network/GethConfig/VersionList.jsx
+++ b/src/containers/Network/GethConfig/VersionList.jsx
@@ -113,7 +113,7 @@ export default class GethConfig extends Component {
     const releases = this.allReleases()
 
     if (releases.length === 0) {
-      return <Spinner style={{ margin: '20px' }} />
+      return <Spinner style={{ margin: '20px 0' }} />
     }
 
     return (

--- a/src/containers/Network/GethConfig/index.js
+++ b/src/containers/Network/GethConfig/index.js
@@ -20,10 +20,6 @@ export default class GethConfig extends Component {
     this.versionListRef = React.createRef()
   }
 
-  renderVersionList = () => {
-    return <VersionList ref={this.versionListRef} />
-  }
-
   renderConfigForm = () => {
     return (
       <div>
@@ -71,18 +67,6 @@ export default class GethConfig extends Component {
     )
   }
 
-  renderTerminal = () => {
-    if (geth.getLogs().length === 0) {
-      return null
-    }
-    return (
-      <div style={{ marginTop: 20 }}>
-        <Typography variant="h6">Terminal</Typography>
-        <Terminal />
-      </div>
-    )
-  }
-
   renderDownloadError() {
     const { downloadError } = this.state
     if (!downloadError) {
@@ -95,10 +79,10 @@ export default class GethConfig extends Component {
   render() {
     return (
       <main>
-        {this.renderVersionList()}
+        <VersionList ref={this.versionListRef} />
         {this.renderConfigForm()}
         {this.renderStartStop()}
-        {this.renderTerminal()}
+        {geth.getLogs().length && <Terminal />}
       </main>
     )
   }

--- a/src/containers/Network/Terminal.jsx
+++ b/src/containers/Network/Terminal.jsx
@@ -1,4 +1,7 @@
 import React, { Component } from 'react'
+import Typography from '@material-ui/core/Typography'
+import Grid from '@material-ui/core/Grid'
+import Button from '../../components/Button'
 import { Mist } from '../../API'
 
 const { geth } = Mist
@@ -9,41 +12,77 @@ function getRandomArbitrary(min, max) {
 
 export default class Terminal extends Component {
   state = {
-    logs: []
+    logs: [],
+    scrollToBottom: true
   }
 
+  logsEnd = React.createRef()
+
   componentDidMount = async () => {
-    const refreshLogs = async () => {
-      const gethLogs = await geth.getLogs()
-      const { logs } = this.state
-      this.setState({
+    setInterval(this.refreshLogs, 1000)
+  }
+
+  refreshLogs = async () => {
+    const { logs, scrollToBottom } = this.state
+
+    const gethLogs = await geth.getLogs()
+
+    this.setState(
+      {
         logs: [...logs, ...gethLogs]
-      })
-    }
-    await refreshLogs()
-    setInterval(refreshLogs, 1000)
+      },
+      () => {
+        if (scrollToBottom) {
+          this.scrollToBottom()
+        }
+      }
+    )
+  }
+
+  scrollToBottom = () => {
+    this.logsEnd.current.scrollIntoView({ bahavior: 'smooth' })
   }
 
   render() {
-    const { logs } = this.state
+    const { logs, scrollToBottom } = this.state
+
     return (
-      <div>
-        <div
-          style={{
-            font:
-              'Lucida Console, Lucida Sans Typewriter, monaco, Bitstream Vera Sans Mono, monospace',
-            background: '#111',
-            color: '#eee',
-            maxHeight: 350,
-            maxWidth: 600,
-            overflowY: 'scroll',
-            padding: 5
-          }}
-        >
-          {logs.map(l => (
-            <div key={getRandomArbitrary(0, 1000000000)}> &gt; {l}</div>
-          ))}
-        </div>
+      <div style={{ marginTop: '20px', maxWidth: 600, padding: 5 }}>
+        <Grid container>
+          <Grid item xs={6}>
+            <Typography variant="h6">Terminal</Typography>
+          </Grid>
+          <Grid item xs={6} style={{ textAlign: 'right' }}>
+            <Button
+              size="small"
+              color="secondary"
+              style={{ marginBottom: '6px' }}
+              onClick={() => this.setState({ scrollToBottom: !scrollToBottom })}
+            >
+              {scrollToBottom ? 'Unfollow Logs' : 'Follow Logs'}
+            </Button>
+          </Grid>
+          <Grid item xs={12}>
+            <div
+              style={{
+                fontFamily:
+                  'Lucida Console, Lucida Sans Typewriter, monaco, Bitstream Vera Sans Mono, monospace',
+                background: '#111',
+                color: '#eee',
+                maxHeight: 350,
+                maxWidth: 600,
+                overflowY: 'scroll',
+                padding: 5,
+                position: 'relative'
+              }}
+            >
+              {logs.map(l => (
+                <div key={getRandomArbitrary(0, 1000000000)}> &gt; {l}</div>
+              ))}
+              <div ref={this.logsEnd} />
+            </div>
+          </Grid>
+        </Grid>
       </div>
     )
   }

--- a/src/theme.js
+++ b/src/theme.js
@@ -15,14 +15,15 @@ const theme = createMuiTheme({
       main: primary
       // dark: will be calculated from palette.primary.main,
       // contrastText: will be calculated to contrast with palette.primary.main
+    },
+    secondary: {
+      // light: '#0066ff',
+      main: '#ffffff'
+      // dark: will be calculated from palette.secondary.main,
+      // contrastText: '#ffcc00',
+      // },
+      // error: will use the default color
     }
-    // secondary: {
-    // light: '#0066ff',
-    // main: '#0044ff',
-    // dark: will be calculated from palette.secondary.main,
-    // contrastText: '#ffcc00',
-    // },
-    // error: will use the default color
   },
   overrides: {
     MuiAppBar: {


### PR DESCRIPTION
#### What does it do?
introduces toggle-able way to follow logs, i.e. you stay scrolled to the bottom of the log file, viewing most recent logs without having to scroll down manually.
#### Any helpful background information?
inspiration from Travis CI, including language used on their button: "Follow Logs"
#### Relevant screenshots?
![screen shot 2019-03-01 at 1 10 24 pm](https://user-images.githubusercontent.com/3621728/53663804-f39a2c00-3c23-11e9-98fd-7ee20eb691cd.png)
