### PR TITLE
fix: directory selector. closes #39

### DIFF
--- a/src/components/Nodes/GethConfig/ConfigForm.jsx
+++ b/src/components/Nodes/GethConfig/ConfigForm.jsx
@@ -248,6 +248,8 @@ class ConfigForm extends Component {
           onClick={this.browseDataDir}
           ref={this.inputOpenFileRef}
           style={{ display: 'none' }}
+          webkitdirectory
+          directory
         />
       </div>
     )


### PR DESCRIPTION
#### What does it do?
Changes selector from file to directory

Thx @varshard https://github.com/ethereum/grid-ui/issues/39