### PR TITLE
fix: ensure previously selected release still exists

### DIFF
--- a/src/components/Nodes/GethConfig/VersionList.jsx
+++ b/src/components/Nodes/GethConfig/VersionList.jsx
@@ -105,14 +105,17 @@ class VersionList extends Component {
     const { client } = this.props
     const { release } = client
     if (selectedRelease) {
+      // Set selectedRelease passed into func
       this.setSelectedRelease(selectedRelease)
-      // Remove selectedRelease from remoteReleases so there are no duplicates in the list
+      // Remove selectedRelease from remoteReleases,
+      // so there are no duplicates in the list
       this.dedupedRemoteReleases()
     } else if (!release.fileName) {
+      // Set latest release if no release selected
       this.setSelectedRelease(localReleases[0])
     } else if (release.fileName) {
       // Ensure previously selected release still exists,
-      // otherwise replace with latest version
+      // otherwise replace with latest release
       if (!localReleases.includes(release)) {
         this.setSelectedRelease(localReleases[0])
       }

--- a/src/components/Nodes/GethConfig/VersionList.jsx
+++ b/src/components/Nodes/GethConfig/VersionList.jsx
@@ -110,6 +110,12 @@ class VersionList extends Component {
       this.dedupedRemoteReleases()
     } else if (!release.fileName) {
       this.setSelectedRelease(localReleases[0])
+    } else if (release.fileName) {
+      // Ensure previously selected release still exists,
+      // otherwise replace with latest version
+      if (!localReleases.includes(release)) {
+        this.setSelectedRelease(localReleases[0])
+      }
     }
   }
 

--- a/src/components/Nodes/GethConfig/VersionList.jsx
+++ b/src/components/Nodes/GethConfig/VersionList.jsx
@@ -155,7 +155,7 @@ class VersionList extends Component {
   }
 
   isLocalRelease = release => {
-    return !release.location.includes('http')
+    return !release.location.includes('https://', 0)
   }
 
   downloadRelease = async release => {


### PR DESCRIPTION
#### What does it do?
Ensures previously selected release still exists after fetching local releases.

Fixes https://github.com/ethereum/grid/issues/130