### PR TITLE
fix: version download UX

### DIFF
--- a/src/components/Nodes/GethConfig/VersionList/AvailableVersionText.js
+++ b/src/components/Nodes/GethConfig/VersionList/AvailableVersionText.js
@@ -1,0 +1,96 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { withStyles } from '@material-ui/core/styles'
+import Typography from '@material-ui/core/Typography'
+import RefreshIcon from '@material-ui/icons/Refresh'
+import Spinner from '../../../shared/Spinner'
+
+const lightGrey = 'rgba(0,0,0,0.25)'
+
+const styles = () => ({
+  refreshIcon: {
+    fontSize: 22,
+    color: lightGrey,
+    marginLeft: 5,
+    verticalAlign: 'middle',
+    marginBottom: 4,
+    visibility: 'hidden'
+  },
+  versionsAvailable: {
+    '&:hover': {
+      cursor: 'pointer'
+    },
+    '&:hover $refreshIcon': {
+      visibility: 'visible'
+    }
+  }
+})
+
+class AvailableVersionText extends Component {
+  static displayName = 'AvailableVersionText'
+
+  static propTypes = {
+    classes: PropTypes.any,
+    getAllReleases: PropTypes.func,
+    localReleases: PropTypes.array,
+    loadRemoteReleases: PropTypes.func,
+    loadingRemoteReleases: PropTypes.array
+  }
+
+  static defaultProps = {}
+
+  render() {
+    const {
+      classes,
+      getAllReleases,
+      localReleases,
+      loadRemoteReleases,
+      loadingRemoteReleases
+    } = this.props
+    const releases = getAllReleases()
+
+    if (releases.length === 0) {
+      return <Spinner style={{ margin: '20px 0' }} />
+    }
+
+    return (
+      <div>
+        {loadingRemoteReleases && (
+          <Typography variant="h6">
+            Loading versions...
+            <RemoteReleaseLoadingSpinner size={18} thickness={4} />
+          </Typography>
+        )}
+        {!loadingRemoteReleases && (
+          <Typography
+            variant="h6"
+            onClick={loadRemoteReleases}
+            classes={{ root: classes.versionsAvailable }}
+          >
+            {releases.length} versions available
+            <RefreshIcon classes={{ root: classes.refreshIcon }} />
+          </Typography>
+        )}
+        <Typography>
+          <StyledDownloadedVersions>
+            {localReleases.length} versions downloaded
+          </StyledDownloadedVersions>
+        </Typography>
+      </div>
+    )
+  }
+}
+
+export default withStyles(styles)(AvailableVersionText)
+
+const RemoteReleaseLoadingSpinner = styled(Spinner)`
+  margin-left: 10px;
+`
+
+const StyledDownloadedVersions = styled.span`
+  color: lightGrey;
+  font-size: 13px;
+  font-weight: bold;
+  text-transform: uppercase;
+`

--- a/src/components/Nodes/GethConfig/VersionList/AvailableVersionText.js
+++ b/src/components/Nodes/GethConfig/VersionList/AvailableVersionText.js
@@ -35,7 +35,7 @@ class AvailableVersionText extends Component {
     getAllReleases: PropTypes.func,
     localReleases: PropTypes.array,
     loadRemoteReleases: PropTypes.func,
-    loadingRemoteReleases: PropTypes.array
+    loadingRemoteReleases: PropTypes.bool
   }
 
   static defaultProps = {}

--- a/src/components/Nodes/GethConfig/VersionList/VersionListItem.js
+++ b/src/components/Nodes/GethConfig/VersionList/VersionListItem.js
@@ -36,7 +36,7 @@ export default class VersionListItem extends Component {
 
     let icon = <BlankIconPlaceholder />
     if (progress) {
-      icon = <Spinner size={20} />
+      icon = <Spinner size={20} value={progress} variant="determinate" />
     } else if (!isLocalRelease()) {
       icon = <CloudDownloadIcon color="primary" />
     } else if (isSelectedRelease()) {

--- a/src/components/Nodes/GethConfig/VersionList/VersionListItem.js
+++ b/src/components/Nodes/GethConfig/VersionList/VersionListItem.js
@@ -81,7 +81,7 @@ export default class VersionListItem extends Component {
         <ListItemTextVersion
           primary={this.releaseDisplayName()}
           isLocalRelease={isLocalRelease()}
-          secondary={progress > 0 ? `${progress}%` : null}
+          secondary={progress >= 0 ? `${progress}%` : null}
         />
         <StyledListItemAction>
           <Typography variant="button" color="primary">

--- a/src/components/Nodes/GethConfig/VersionList/VersionListItem.js
+++ b/src/components/Nodes/GethConfig/VersionList/VersionListItem.js
@@ -36,7 +36,7 @@ export default class VersionListItem extends Component {
 
     let icon = <BlankIconPlaceholder />
     if (progress) {
-      icon = <Spinner variant="determinate" size={20} value={progress} />
+      icon = <Spinner size={20} />
     } else if (!isLocalRelease()) {
       icon = <CloudDownloadIcon color="primary" />
     } else if (isSelectedRelease()) {

--- a/src/components/Nodes/GethConfig/VersionList/VersionListItem.js
+++ b/src/components/Nodes/GethConfig/VersionList/VersionListItem.js
@@ -1,0 +1,149 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import styled, { css } from 'styled-components'
+import ListItem from '@material-ui/core/ListItem'
+import ListItemIcon from '@material-ui/core/ListItemIcon'
+import ListItemText from '@material-ui/core/ListItemText'
+import CloudDownloadIcon from '@material-ui/icons/CloudDownload'
+import CheckBoxIcon from '@material-ui/icons/CheckBox'
+import Typography from '@material-ui/core/Typography'
+import { without } from '../../../../lib/utils'
+import Spinner from '../../../shared/Spinner'
+
+export default class VersionListItem extends Component {
+  static displayName = 'VersionListItem'
+
+  static propTypes = {
+    handleReleaseSelected: PropTypes.func,
+    isSelectedRelease: PropTypes.func,
+    isLocalRelease: PropTypes.func,
+    fileName: PropTypes.string,
+    name: PropTypes.string,
+    progress: PropTypes.number
+  }
+
+  static defaultProps = {}
+
+  releaseDisplayName = () => {
+    const { fileName } = this.props
+    const nameParts = fileName.split('-')
+    const name = `${nameParts[0]} ${nameParts[1]} ${nameParts[3]}`
+    return name
+  }
+
+  renderIcon = () => {
+    const { isLocalRelease, isSelectedRelease, progress } = this.props
+
+    let icon = <BlankIconPlaceholder />
+    if (progress) {
+      icon = <Spinner variant="determinate" size={20} value={progress} />
+    } else if (!isLocalRelease()) {
+      icon = <CloudDownloadIcon color="primary" />
+    } else if (isSelectedRelease()) {
+      icon = <CheckBoxIcon color="primary" />
+    } else if (isLocalRelease()) {
+      icon = <HiddenCheckBoxIcon color="primary" />
+    }
+    return icon
+  }
+
+  render() {
+    const {
+      handleReleaseSelected,
+      isLocalRelease,
+      isSelectedRelease,
+      name,
+      progress
+    } = this.props
+
+    let actionLabel
+    if (isLocalRelease()) {
+      actionLabel = 'Use'
+      if (isSelectedRelease()) {
+        actionLabel = 'Selected'
+      }
+    } else {
+      actionLabel = 'Download'
+      if (progress) {
+        actionLabel = 'Downloading'
+      }
+    }
+
+    return (
+      <StyledListItem
+        button
+        onClick={() => handleReleaseSelected()}
+        selected={isSelectedRelease()}
+        isDownloading={!!progress}
+        alt={name}
+      >
+        <ListItemIcon>{this.renderIcon()}</ListItemIcon>
+        <ListItemTextVersion
+          primary={this.releaseDisplayName()}
+          isLocalRelease={isLocalRelease()}
+          secondary={progress > 0 ? `${progress}%` : null}
+        />
+        <StyledListItemAction>
+          <Typography variant="button" color="primary">
+            {actionLabel}
+          </Typography>
+        </StyledListItemAction>
+      </StyledListItem>
+    )
+  }
+}
+
+const HiddenCheckBoxIcon = styled(CheckBoxIcon)`
+  visibility: hidden;
+`
+
+const StyledListItemAction = styled.span`
+  text-transform: uppercase;
+`
+
+const StyledListItem = styled(without('isDownloading')(ListItem))`
+${props =>
+  !props.selected &&
+  css`
+    ${StyledListItemAction} {
+      visibility: hidden;
+    }
+  `}
+  &:hover ${StyledListItemAction} {
+    visibility: visible;
+  }
+  &:hover ${HiddenCheckBoxIcon} {
+    visibility: visible;
+  }
+  ${props =>
+    props.isDownloading &&
+    css`
+      ${StyledListItemAction} {
+        visibility: visible;
+      }
+    `}
+`
+
+const ListItemTextVersion = styled(({ isLocalRelease, children, ...rest }) => (
+  <ListItemText
+    {...rest}
+    primaryTypographyProps={{
+      style: { color: isLocalRelease ? 'black' : 'grey' }
+    }}
+  >
+    {children}
+  </ListItemText>
+))`
+  text-transform: capitalize;
+  ${props =>
+    props.isLocalRelease &&
+    css`
+      font-weight: bold;
+      color: grey;
+    `}
+`
+
+const BlankIconPlaceholder = styled.div`
+  width: 24px;
+  height: 24px;
+`

--- a/src/components/Nodes/GethConfig/VersionList/VersionListItem.js
+++ b/src/components/Nodes/GethConfig/VersionList/VersionListItem.js
@@ -85,7 +85,7 @@ export default class VersionListItem extends Component {
         <ListItemTextVersion
           primary={this.releaseDisplayName()}
           isLocalRelease={isLocalRelease()}
-          secondary={progress >= 0 ? `${progress}%` : null}
+          secondary={progress > 0 ? `${progress}%` : null}
         />
         <StyledListItemAction>
           <Typography variant="button" color="primary">

--- a/src/components/Nodes/GethConfig/VersionList/index.js
+++ b/src/components/Nodes/GethConfig/VersionList/index.js
@@ -164,7 +164,7 @@ class VersionList extends Component {
           message={
             <span>
               You are using an older version of Geth ({selectedVersion})<br />
-              New releases contain performance and security enhancements.
+              Newer releases contain performance and security enhancements.
             </span>
           }
           onDismiss={this.onDismissError}

--- a/src/components/Nodes/GethConfig/VersionList/index.js
+++ b/src/components/Nodes/GethConfig/VersionList/index.js
@@ -153,7 +153,7 @@ class VersionList extends Component {
     if (!release || !remoteReleases.length) {
       return null
     }
-    const latestRelease = this.getAllReleases()[0]
+    const latestRelease = remoteReleases[0]
     const latestVersion = latestRelease.version
     const selectedVersion = release.version
 

--- a/src/components/Nodes/GethConfig/VersionList/index.js
+++ b/src/components/Nodes/GethConfig/VersionList/index.js
@@ -98,9 +98,11 @@ class VersionList extends Component {
     dispatch(setRelease({ release }))
   }
 
+  deepClone = input => JSON.parse(JSON.stringify(input))
+
   loadRemoteReleases = async () => {
     this.setState({ loadingRemoteReleases: true })
-    const releases = await geth.getReleases()
+    const releases = this.deepClone(await geth.getReleases())
     const remoteReleases = releases
       .filter(this.excludeUnstableReleases)
       .filter(this.excludeRemoteOfAlreadyInstalledReleases)

--- a/src/components/Nodes/GethConfig/VersionList/index.js
+++ b/src/components/Nodes/GethConfig/VersionList/index.js
@@ -117,7 +117,7 @@ class VersionList extends Component {
     // Add `progress` property to release
     const updatedReleases = remoteReleases.slice()
     updatedReleases[index].progress = 0
-    this.setState({ remoteReleases: updatedReleases })
+    this.updateDownloadProgress(index, 0, release)
 
     try {
       geth.download(release, progress => {

--- a/src/components/Nodes/GethConfig/VersionList/index.js
+++ b/src/components/Nodes/GethConfig/VersionList/index.js
@@ -224,8 +224,8 @@ class VersionList extends Component {
           loadingRemoteReleases={loadingRemoteReleases}
           getAllReleases={this.getAllReleases}
         />
-        {this.renderLatestVersionWarning()}
         {this.renderVersionList()}
+        {this.renderLatestVersionWarning()}
         {downloadError && <StyledError>{downloadError}</StyledError>}
       </div>
     )
@@ -241,8 +241,7 @@ function mapStateToProps(state) {
 export default connect(mapStateToProps)(VersionList)
 
 const StyledList = styled(List)`
-  max-height: 200px;
-  max-width: 500px;
+  max-height: 260px;
   overflow: scroll;
 `
 

--- a/src/components/Nodes/GethConfig/VersionList/index.js
+++ b/src/components/Nodes/GethConfig/VersionList/index.js
@@ -30,8 +30,19 @@ class VersionList extends Component {
 
   excludeAlreadyInstalledReleases = release => {
     const { localReleases } = this.state
-    const versions = localReleases.map(r => r.version)
-    return !versions.includes(release.version)
+    const versions = localReleases.map(r => r.fileName)
+    return !versions.includes(release.fileName)
+  }
+
+  excludeRemoteOfAlreadyInstalledReleases = release => {
+    const isLocal = this.isLocalRelease(release)
+    if (isLocal) return true
+
+    const { localReleases } = this.state
+    const versions = localReleases.map(r => r.fileName)
+    const hasLocalCounterpart = versions.includes(release.fileName)
+
+    return !hasLocalCounterpart
   }
 
   getAllReleases = () => {
@@ -92,7 +103,7 @@ class VersionList extends Component {
     const releases = await geth.getReleases()
     const remoteReleases = releases
       .filter(this.excludeUnstableReleases)
-      .filter(this.excludeAlreadyInstalledReleases)
+      .filter(this.excludeRemoteOfAlreadyInstalledReleases)
     this.setState({ remoteReleases })
     this.setState({ loadingRemoteReleases: false })
   }
@@ -164,7 +175,7 @@ class VersionList extends Component {
           message={
             <span>
               You are using an older version of Geth ({selectedVersion})<br />
-              Newer releases contain performance and security enhancements.
+              New releases contain performance and security enhancements.
             </span>
           }
           onDismiss={this.onDismissError}

--- a/src/components/Nodes/GethConfig/VersionList/index.js
+++ b/src/components/Nodes/GethConfig/VersionList/index.js
@@ -3,44 +3,27 @@ import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import styled, { css } from 'styled-components'
 import semver from 'semver'
-import { withStyles } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
 import Button from '@material-ui/core/Button'
 import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemIcon from '@material-ui/core/ListItemIcon'
 import ListItemText from '@material-ui/core/ListItemText'
-import SnackbarContent from '@material-ui/core/SnackbarContent'
 import CloudDownloadIcon from '@material-ui/icons/CloudDownload'
 import CheckBoxIcon from '@material-ui/icons/CheckBox'
-import WarningIcon from '@material-ui/icons/Warning'
-import amber from '@material-ui/core/colors/amber'
-import Spinner from '../../shared/Spinner'
-import { Mist } from '../../../API'
-import { without } from '../../../lib/utils'
-import { setRelease } from '../../../store/client/actions'
-import AvailableVersionText from './VersionList/AvailableVersionText'
+import Spinner from '../../../shared/Spinner'
+import Notification from '../../../shared/Notification'
+import { Mist } from '../../../../API'
+import { without } from '../../../../lib/utils'
+import { setRelease } from '../../../../store/client/actions'
+import AvailableVersionText from './AvailableVersionText'
 
 const { geth } = Mist
-
-const styles = () => ({
-  warning: {
-    backgroundColor: amber[700],
-    opacity: 0.9,
-    margin: '10px 0 15px 0'
-  },
-  warningIcon: {
-    fontSize: 19,
-    verticalAlign: 'middle',
-    marginBottom: 2
-  }
-})
 
 class VersionList extends Component {
   static propTypes = {
     dispatch: PropTypes.func,
-    client: PropTypes.object,
-    classes: PropTypes.object
+    client: PropTypes.object
   }
 
   state = {
@@ -167,12 +150,8 @@ class VersionList extends Component {
     this.loadLocalReleases(release)
   }
 
-  renderWarnings = () => {
-    return <div>{this.renderLatestVersionWarning()}</div>
-  }
-
   renderLatestVersionWarning = () => {
-    const { classes, client } = this.props
+    const { client } = this.props
     const { remoteReleases } = this.state
     const { release } = client
     if (!release || !remoteReleases.length) {
@@ -181,17 +160,18 @@ class VersionList extends Component {
     const latestRelease = this.getAllReleases()[0]
     const latestVersion = latestRelease.version
     const selectedVersion = release.version
+
     if (semver.compare(selectedVersion, latestVersion)) {
       return (
-        <SnackbarContent
-          classes={{ root: classes.warning }}
+        <Notification
+          type="warning"
           message={
             <span>
-              <WarningIcon classes={{ root: classes.warningIcon }} /> You are
-              using an older version of Geth ({selectedVersion})<br />
+              You are using an older version of Geth ({selectedVersion})<br />
               New releases contain performance and security enhancements.
             </span>
           }
+          onDismiss={this.onDismissError}
           action={
             <Button
               onClick={() => {
@@ -287,7 +267,7 @@ class VersionList extends Component {
           loadingRemoteReleases={loadingRemoteReleases}
           getAllReleases={this.getAllReleases}
         />
-        {this.renderWarnings()}
+        {this.renderLatestVersionWarning()}
         {this.renderVersionList()}
         {downloadError && <StyledError>{downloadError}</StyledError>}
       </div>
@@ -301,7 +281,7 @@ function mapStateToProps(state) {
   }
 }
 
-export default connect(mapStateToProps)(withStyles(styles)(VersionList))
+export default connect(mapStateToProps)(VersionList)
 
 const StyledList = styled(List)`
   max-height: 200px;

--- a/src/components/Nodes/GethConfig/index.js
+++ b/src/components/Nodes/GethConfig/index.js
@@ -114,9 +114,7 @@ class GethConfig extends Component {
           </Tabs>
         </StyledAppBar>
         <TabContainer style={{ display: activeTab === 0 ? 'block' : 'none' }}>
-          <div>
-            <VersionList />
-          </div>
+          <VersionList />
         </TabContainer>
         <TabContainer style={{ display: activeTab === 2 ? 'block' : 'none' }}>
           <Terminal />

--- a/src/components/shared/Notification.js
+++ b/src/components/shared/Notification.js
@@ -23,7 +23,9 @@ const styles = theme => ({
     backgroundColor: theme.palette.primary.dark
   },
   warning: {
-    backgroundColor: amber[700]
+    backgroundColor: amber[700],
+    opacity: 0.9,
+    margin: '10px 0 15px 0'
   },
   icon: {
     fontSize: 20,
@@ -41,14 +43,15 @@ const styles = theme => ({
 
 class Notification extends Component {
   static propTypes = {
+    action: PropTypes.node,
     classes: PropTypes.object,
     type: PropTypes.string,
-    message: PropTypes.string,
+    message: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
     onDismiss: PropTypes.func
   }
 
   render() {
-    const { classes, message, type, onDismiss } = this.props
+    const { classes, action, message, type, onDismiss } = this.props
     const inlineIconClasses = {
       classes: {
         root: classNames(classes.icon, classes.inlineIcon)
@@ -78,6 +81,19 @@ class Notification extends Component {
         break
     }
 
+    const customAction = action || [
+      <IconButton
+        key="close"
+        aria-label="Close"
+        color="inherit"
+        onClick={onDismiss}
+      >
+        <CloseIcon
+          classes={{ root: classNames(classes.icon, classes.closeIcon) }}
+        />
+      </IconButton>
+    ]
+
     return (
       <SnackbarContent
         classes={{ root: snackbarClasses }}
@@ -87,18 +103,7 @@ class Notification extends Component {
             {message}
           </span>
         }
-        action={[
-          <IconButton
-            key="close"
-            aria-label="Close"
-            color="inherit"
-            onClick={onDismiss}
-          >
-            <CloseIcon
-              classes={{ root: classNames(classes.icon, classes.closeIcon) }}
-            />
-          </IconButton>
-        ]}
+        action={customAction}
       />
     )
   }


### PR DESCRIPTION
#### What does it do?
- improves UX when downloading new geth versions
- refactors VersionList components into smaller, more manageable pieces
- extends Notification to accept custom actions, and uses it within VersionList
#### Any helpful background information?
- we were manipulating state outside of React's lifecycle + setState methods. let's avoid that.
- download state updates are restricted to every 10% progress
#### Does it close any issues?
- closes https://github.com/ethereum/grid/issues/137
- closes https://github.com/ethereum/grid/issues/121