### PR TITLE
Fix: makes terminal pane totally fluid with internal scrolling

### DIFF
--- a/src/components/Nodes/Terminal.jsx
+++ b/src/components/Nodes/Terminal.jsx
@@ -84,16 +84,21 @@ export default class Terminal extends Component {
           key="terminalWrapper"
           ref={this.terminalScrollViewRef}
           style={{
+            background: '#111',
+            color: '#eee',
             fontFamily:
               'Lucida Console, Lucida Sans Typewriter, monaco, Bitstream Vera Sans Mono, monospace',
             fontSize: '11px',
-            background: '#111',
-            color: '#eee',
-            maxHeight: 400,
-            width: '100%',
+            padding: 10,
+
+            // Fluid width and height with support to scrolling
+            width: 'calc(100vw - 310px)',
+            maxHeight: 'calc(100vh - 225px)',
+
+            // Scroll config
+            overflowX: 'auto',
             overflowY: 'scroll',
-            whiteSpace: 'nowrap',
-            padding: 10
+            whiteSpace: 'nowrap'
           }}
         >
           {logs.map((l, index) => (


### PR DESCRIPTION
#### What does it do?
It removes fixed height of the terminal and enables totally fluid terminal window, while allowing internal scrolling.

#### Relevant screenshots?
<img width="727" alt="Screen Shot 2019-04-16 at 12 07 41 PM" src="https://user-images.githubusercontent.com/47108/56226006-64649e80-6040-11e9-85de-5a93a2507fb4.png">
<img width="1143" alt="Screen Shot 2019-04-16 at 12 07 48 PM" src="https://user-images.githubusercontent.com/47108/56226007-64649e80-6040-11e9-8568-7dd80c92cb1d.png">
<img width="1703" alt="Screen Shot 2019-04-16 at 12 07 58 PM" src="https://user-images.githubusercontent.com/47108/56226008-64649e80-6040-11e9-80f3-0436838215e3.png">


#### Does it close any issues?
Front-end fix of https://github.com/ethereum/grid/issues/157