### PR TITLE
Style: adds fluid height to versionList component

### DIFF
--- a/src/components/Nodes/ClientConfig/VersionList.jsx
+++ b/src/components/Nodes/ClientConfig/VersionList.jsx
@@ -253,7 +253,7 @@ export default connect(mapStateToProps)(withStyles(styles)(VersionList))
 
 const StyledList = styled(List)`
   min-height: 200px;
-  max-height: 300px;
+  max-height: calc(100vh - 295px);
   overflow-y: scroll;
 `
 


### PR DESCRIPTION
#### What does it do?
Makes versionList height follow window height.

#### Relevant screenshots?
<img width="881" alt="Screen Shot 2019-04-16 at 2 22 20 PM" src="https://user-images.githubusercontent.com/47108/56234538-7c91e900-6053-11e9-9d49-338e42b770fd.png">
<img width="1171" alt="Screen Shot 2019-04-16 at 2 22 04 PM" src="https://user-images.githubusercontent.com/47108/56234539-7c91e900-6053-11e9-9331-df56d2651476.png">
<img width="1143" alt="Screen Shot 2019-04-16 at 2 21 59 PM" src="https://user-images.githubusercontent.com/47108/56234540-7c91e900-6053-11e9-83ba-1c49d86ef7f3.png">

#### Does it close any issues?
Closes https://github.com/ethereum/grid/issues/168.