### PR TITLE
fix: captures connection status

### DIFF
--- a/src/components/Nodes/ClientConfig/index.js
+++ b/src/components/Nodes/ClientConfig/index.js
@@ -9,7 +9,7 @@ import Typography from '@material-ui/core/Typography'
 import VersionList from './VersionList'
 import ConfigForm from './ConfigForm'
 import Terminal from '../Terminal'
-import NodeInfo from '../NodeInfo'
+// import NodeInfo from '../NodeInfo'
 import { clearError } from '../../../store/client/actions'
 import Notification from '../../shared/Notification'
 
@@ -103,7 +103,7 @@ class ClientConfig extends Component {
       <StyledMain>
         <Typography variant="h5">
           {clientName}
-          <NodeInfo />
+          {/* <NodeInfo /> */}
         </Typography>
         <Typography variant="subtitle1" gutterBottom>
           <StyledState>{isActiveClient ? clientStatus : 'STOPPED'}</StyledState>

--- a/src/components/Nodes/index.js
+++ b/src/components/Nodes/index.js
@@ -39,7 +39,6 @@ class NodesTab extends Component {
 
   handleSelect = client => {
     const { dispatch } = this.props
-    console.log('handle select', client)
     dispatch(selectClient(client.plugin.config))
     this.setState({ selectedClient: client })
   }

--- a/src/components/Nodes/index.js
+++ b/src/components/Nodes/index.js
@@ -27,7 +27,8 @@ class NodesTab extends Component {
     if (!PluginHost) return
     const plugins = PluginHost.getAllPlugins()
     const clients = [...plugins]
-    const selectedClient = clients[0]
+    const selectedClient =
+      clients.find(client => client.order === 1) || clients[0]
     dispatch(selectClient(selectedClient.plugin.config))
     this.setState({ clients, selectedClient })
   }
@@ -74,12 +75,10 @@ class NodesTab extends Component {
   }
 
   render() {
-    const { active, clients, selectedClient, selectedRelease } = this.state
+    const { clients, selectedClient, selectedRelease } = this.state
 
     return (
       <ServicesNav
-        active={active}
-        setActive={service => this.setState({ active: service })}
         handleToggle={this.handleToggle}
         handleSelect={this.handleSelect}
         clients={clients}

--- a/src/components/Webview/index.jsx
+++ b/src/components/Webview/index.jsx
@@ -21,15 +21,15 @@ class Webview extends React.Component {
   }
 
   handleDomReady = () => {
-    console.log('dom ready')
+    console.log('Webview: DOM ready')
   }
 
   handleWillNavigate = () => {
-    console.log('will navigate')
+    console.log('Webview: will navigate')
   }
 
   handleIpcMessage = () => {
-    console.log('handle ipc')
+    console.log('Webview: handle ipc')
   }
 
   handleNavigate = newUrl => {

--- a/src/store/client/actions.js
+++ b/src/store/client/actions.js
@@ -106,7 +106,7 @@ export const clientError = error => {
 function createListeners(client, dispatch) {
   client.on('starting', () => dispatch(onConnectionUpdate('STARTING')))
   client.on('started', () => dispatch(onConnectionUpdate('STARTED')))
-  client.on('connect', () => dispatch(onConnectionUpdate('CONNECTED')))
+  client.on('connected', () => dispatch(onConnectionUpdate('CONNECTED')))
   client.on('stopping', () => dispatch(onConnectionUpdate('STOPPING')))
   client.on('stopped', () => dispatch(onConnectionUpdate('STOPPED')))
   client.on('disconnect', () => dispatch(onConnectionUpdate('DISCONNETED')))
@@ -116,7 +116,7 @@ function createListeners(client, dispatch) {
 function removeListeners(client) {
   client.removeAllListeners('starting')
   client.removeAllListeners('started')
-  client.removeAllListeners('connect')
+  client.removeAllListeners('connected')
   client.removeAllListeners('stopping')
   client.removeAllListeners('stopped')
   client.removeAllListeners('disconnect')

--- a/src/store/client/actions.js
+++ b/src/store/client/actions.js
@@ -67,41 +67,6 @@ export const updateSyncMode = ({ syncMode }) => {
   }
 }
 
-export const gethStarting = () => {
-  return { type: '[CLIENT]:GETH:STARTING' }
-}
-
-export const gethStarted = () => {
-  return { type: '[CLIENT]:GETH:STARTED' }
-}
-
-export const gethConnected = () => {
-  return { type: '[CLIENT]:GETH:CONNECTED' }
-}
-
-export const gethDisconnected = () => {
-  return { type: '[CLIENT]:GETH:DISCONNECTED' }
-}
-
-export const gethStopping = () => {
-  return { type: '[CLIENT]:GETH:STOPPING' }
-}
-
-export const gethStopped = () => {
-  return { type: '[CLIENT]:GETH:STOPPED' }
-}
-
-export const gethError = ({ error }) => {
-  return { type: '[CLIENT]:GETH:ERROR', error }
-}
-
-export const setRelease = release => {
-  return {
-    type: 'CLIENT:SET_RELEASE',
-    payload: { release }
-  }
-}
-
 export const setConfig = ({ config }) => {
   Geth.setConfig(config)
 
@@ -123,9 +88,45 @@ export const selectClient = clientData => {
   return { type: 'CLIENT:SELECT', payload: { clientData } }
 }
 
+export const setRelease = release => {
+  return {
+    type: 'CLIENT:SET_RELEASE',
+    payload: { release }
+  }
+}
+
+function onConnectionUpdate(status) {
+  return { type: 'CLIENT:STATUS_UPDATE', payload: { status } }
+}
+
+export const clientError = error => {
+  return { type: 'CLIENT:ERROR', error }
+}
+
+function createListeners(client, dispatch) {
+  client.on('starting', () => dispatch(onConnectionUpdate('STARTING')))
+  client.on('started', () => dispatch(onConnectionUpdate('STARTED')))
+  client.on('connect', () => dispatch(onConnectionUpdate('CONNECTED')))
+  client.on('stopping', () => dispatch(onConnectionUpdate('STOPPING')))
+  client.on('stopped', () => dispatch(onConnectionUpdate('STOPPED')))
+  client.on('disconnect', () => dispatch(onConnectionUpdate('DISCONNETED')))
+  client.on('error', e => dispatch(clientError(e)))
+}
+
+function removeListeners(client) {
+  client.removeAllListeners('starting')
+  client.removeAllListeners('started')
+  client.removeAllListeners('connect')
+  client.removeAllListeners('stopping')
+  client.removeAllListeners('stopped')
+  client.removeAllListeners('disconnect')
+  client.removeAllListener('error')
+}
+
 export const startClient = (client, release, config) => {
   return dispatch => {
     try {
+      createListeners(client, dispatch)
       client.start(release, config)
       return dispatch({
         type: 'CLIENT:START',
@@ -141,6 +142,7 @@ export const stopClient = client => {
   return dispatch => {
     try {
       client.stop()
+      removeListeners(client)
       dispatch({ type: 'CLIENT:STOP' })
     } catch (e) {
       dispatch({ type: 'CLIENT:STOP:ERROR', error: e.toString() })

--- a/src/store/client/actions.js
+++ b/src/store/client/actions.js
@@ -120,7 +120,7 @@ function removeListeners(client) {
   client.removeAllListeners('stopping')
   client.removeAllListeners('stopped')
   client.removeAllListeners('disconnect')
-  client.removeAllListener('error')
+  client.removeAllListeners('error')
 }
 
 export const startClient = (client, release, config) => {

--- a/src/store/client/gethService.js
+++ b/src/store/client/gethService.js
@@ -1,17 +1,6 @@
 import { BigNumber } from 'bignumber.js'
 import { Mist } from '../../API'
-import {
-  newBlock,
-  updateSyncing,
-  updatePeerCount,
-  gethStarting,
-  gethStarted,
-  gethConnected,
-  gethDisconnected,
-  gethStopping,
-  gethStopped,
-  gethError
-} from './actions'
+import { newBlock, updateSyncing, updatePeerCount } from './actions'
 
 const { geth } = Mist
 
@@ -164,56 +153,32 @@ class GethService {
     this.syncingSubscriptionId = null
   }
 
-  onStarting(dispatch) {
-    dispatch(gethStarting())
-  }
+  // onConnect(dispatch) {
+  // dispatch(gethConnected())
 
-  onStarted(dispatch) {
-    dispatch(gethStarted())
-  }
-
-  onConnect(dispatch) {
-    dispatch(gethConnected())
-
-    const startSubscriptions = async () => {
-      const result = await geth.rpc('eth_syncing')
-      if (result === false) {
-        // Not syncing, start newHeads subscription
-        this.startNewHeadsSubscription(dispatch)
-      } else {
-        // Subscribe to syncing
-        this.startSyncingSubscription(dispatch)
-      }
-    }
-    const setLastBlock = () => {
-      geth.rpc('eth_getBlockByNumber', ['latest', false]).then(block => {
-        const { number: hexBlockNumber, timestamp: hexTimestamp } = block
-        const blockNumber = Number(toNumberString(hexBlockNumber))
-        const timestamp = Number(toNumberString(hexTimestamp))
-        dispatch(newBlock({ blockNumber, timestamp }))
-      })
-    }
-    setTimeout(() => {
-      setLastBlock()
-      startSubscriptions()
-    }, 2000)
-  }
-
-  onDisconnect(dispatch) {
-    dispatch(gethDisconnected())
-  }
-
-  onStopping(dispatch) {
-    dispatch(gethStopping())
-  }
-
-  onStopped(dispatch) {
-    dispatch(gethStopped())
-  }
-
-  onError(error, dispatch) {
-    dispatch(gethError({ error }))
-  }
+  // const startSubscriptions = async () => {
+  // const result = await geth.rpc('eth_syncing')
+  // if (result === false) {
+  // // Not syncing, start newHeads subscription
+  // this.startNewHeadsSubscription(dispatch)
+  // } else {
+  // // Subscribe to syncing
+  // this.startSyncingSubscription(dispatch)
+  // }
+  // }
+  // const setLastBlock = () => {
+  // geth.rpc('eth_getBlockByNumber', ['latest', false]).then(block => {
+  // const { number: hexBlockNumber, timestamp: hexTimestamp } = block
+  // const blockNumber = Number(toNumberString(hexBlockNumber))
+  // const timestamp = Number(toNumberString(hexTimestamp))
+  // dispatch(newBlock({ blockNumber, timestamp }))
+  // })
+  // }
+  // setTimeout(() => {
+  // setLastBlock()
+  // startSubscriptions()
+  // }, 2000)
+  // }
 
   async startNewHeadsSubscription(dispatch) {
     geth.rpc('eth_subscribe', ['newHeads']).then(subscriptionId => {

--- a/src/store/client/reducer.js
+++ b/src/store/client/reducer.js
@@ -57,6 +57,10 @@ const client = (state = initialState, action) => {
       const { name, version } = action.payload
       return { ...state, active: { name, version, status: 'STARTED' } }
     }
+    case 'CLIENT:STATUS_UPDATE': {
+      const { status } = action.payload
+      return { ...state, active: { ...state.active, status } }
+    }
     case 'CLIENT:STOP': {
       return { ...state, active: { ...initialState.active } }
     }
@@ -67,24 +71,6 @@ const client = (state = initialState, action) => {
     case '[CLIENT]:GETH:SET_CONFIG': {
       const { config } = action.payload
       return { ...state, config }
-    }
-    case '[CLIENT]:GETH:STARTED': {
-      return { ...state, state: 'STARTED' }
-    }
-    case '[CLIENT]:GETH:STARTING': {
-      return { ...state, state: 'STARTING' }
-    }
-    case '[CLIENT]:GETH:STOPPING': {
-      return { ...state, state: 'STOPPING' }
-    }
-    case '[CLIENT]:GETH:STOPPED': {
-      return { ...state, state: 'STOPPED' }
-    }
-    case '[CLIENT]:GETH:CONNECTED': {
-      return { ...state, state: 'CONNECTED' }
-    }
-    case '[CLIENT]:GETH:DISCONNECTED': {
-      return { ...state, state: 'STARTED' }
     }
     case '[CLIENT]:GETH:ERROR': {
       const { error } = action

--- a/src/store/client/reducer.js
+++ b/src/store/client/reducer.js
@@ -55,7 +55,7 @@ const client = (state = initialState, action) => {
     }
     case 'CLIENT:START': {
       const { name, version } = action.payload
-      return { ...state, active: { name, version, status: 'STARTED' } }
+      return { ...state, active: { name, version } }
     }
     case 'CLIENT:STATUS_UPDATE': {
       const { status } = action.payload


### PR DESCRIPTION
#### What does it do?
- stubs out NodeInfo until its providing value
- displays accurate client connection status, e.g. "CONNECTED", rather than just "STARTED" or "STOPPED"
#### Relevant screenshots?
![Screen Shot 2019-04-17 at 11 15 34 AM](https://user-images.githubusercontent.com/3621728/56309090-1ade8700-6106-11e9-8255-b43793cbad30.png)
#### Does it close any issues?
closes https://github.com/ethereum/grid/issues/176
fixes https://github.com/ethereum/grid/issues/181