### PR TITLE
style: Enables ansi coloring on terminal output

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@material-ui/core": "^3.9.2",
     "@material-ui/icons": "^3.0.2",
+    "ansi-to-react": "^5.0.0",
     "bignumber.js": "^7.2.1",
     "bn.js": "^4.11.8",
     "classnames": "^2.2.6",

--- a/src/components/Nodes/Terminal.jsx
+++ b/src/components/Nodes/Terminal.jsx
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import Ansi from 'ansi-to-react'
 
 export default class Terminal extends Component {
   static propTypes = {
@@ -102,7 +103,10 @@ export default class Terminal extends Component {
           }}
         >
           {logs.map((l, index) => (
-            <div key={index}> &gt; {l}</div>
+            <div key={index}>
+              {' '}
+              &gt; <Ansi>{l}</Ansi>
+            </div>
           ))}
         </div>
       </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1226,6 +1226,11 @@ alphanum-sort@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
 
+anser@^1.4.1:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/anser/-/anser-1.4.8.tgz#19a3bfc5f0e31c49efaea38f58fd0d136597f2a3"
+  integrity sha512-tVHucTCKIt9VRrpQKzPtOlwm/3AmyQ7J+QE29ixFnvuE2hm83utEVrN7jJapYkHV6hI0HOHkEX9TOMCzHtwvuA==
+
 ansi-colors@^3.0.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.1.tgz#9638047e4213f3428a11944a7d4b31cba0a3ff95"
@@ -1265,6 +1270,14 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   dependencies:
     color-convert "^1.9.0"
+
+ansi-to-react@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-to-react/-/ansi-to-react-5.0.0.tgz#0bff17327478e6df2c754892dd5fcfe841ff7b5a"
+  integrity sha512-eG0e1PjxtdjH/YqmNWK7/7fbA++q7FamY/Fsv3yE3CV/v7RQmUACXneNrnezl5tpsii2BcfH9wri7s5tp40gVA==
+  dependencies:
+    anser "^1.4.1"
+    escape-carriage "^1.3.0"
 
 any-observable@^0.3.0:
   version "0.3.0"
@@ -3829,6 +3842,11 @@ es6-promisify@^5.0.0:
   resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
   dependencies:
     es6-promise "^4.0.3"
+
+escape-carriage@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/escape-carriage/-/escape-carriage-1.3.0.tgz#71006b2d4da8cb6828686addafcb094239c742f3"
+  integrity sha512-ATWi5MD8QlAGQOeMgI8zTp671BG8aKvAC0M7yenlxU4CRLGO/sKthxVUyjiOFKjHdIo+6dZZUNFgHFeVEaKfGQ==
 
 escape-html@~1.0.3:
   version "1.0.3"


### PR DESCRIPTION
#### What does it do?
Enables colored terminal output, parsing those garbage-like characters that Aleth and potentially other clients use on their output.

#### Any helpful background information?


#### New dependencies? What are they used for?
[ANSI to React](https://www.npmjs.com/package/ansi-to-react)

#### Relevant screenshots?
![unknown (1)](https://user-images.githubusercontent.com/47108/56433211-1cdb4e00-629e-11e9-9982-8e1e2b75f999.png)

#### Does it close any issues?
https://github.com/ethereum/grid/issues/184