### PR TITLE
Experiment: removing clutter from the UI

### DIFF
--- a/src/components/NavTabs.js
+++ b/src/components/NavTabs.js
@@ -53,6 +53,25 @@ class NavTabs extends React.Component {
     this.setState({ activeTab })
   }
 
+  renderAppBar() {
+    const { classes } = this.props
+    const { activeTab } = this.state
+
+    return (
+      <AppBar position="fixed" className={classes.appBar}>
+        <Tabs
+          value={activeTab}
+          onChange={this.handleTabChange}
+          textColor="primary"
+          indicatorColor="primary"
+        >
+          <Tab label="Nodes" data-test-id="navbar-item-nodes" />
+          <Tab label="Webview" data-test-id="navbar-item-webview" />
+        </Tabs>
+      </AppBar>
+    )
+  }
+
   render() {
     const { classes } = this.props
     const { activeTab } = this.state
@@ -60,24 +79,6 @@ class NavTabs extends React.Component {
     return (
       <div className={classes.root}>
         <CssBaseline />
-        <AppBar position="fixed" className={classes.appBar}>
-          <Tabs
-            value={activeTab}
-            onChange={this.handleTabChange}
-            textColor="primary"
-            indicatorColor="primary"
-          >
-            <Tab label="Nodes" data-test-id="navbar-item-nodes" />
-            <Tab label="Network" data-test-id="navbar-item-network" disabled />
-            <Tab
-              label="Transactions"
-              data-test-id="navbar-item-transactions"
-              disabled
-            />
-            <Tab label="Tools" data-test-id="navbar-item-tools" disabled />
-            <Tab label="Webview" data-test-id="navbar-item-webview" />
-          </Tabs>
-        </AppBar>
 
         <Typography
           component="div"
@@ -89,18 +90,6 @@ class NavTabs extends React.Component {
           <NodesTab />
         </Typography>
 
-        <TabContainer style={{ display: activeTab === 1 ? 'block' : 'none' }}>
-          <Typography component="h6">Network</Typography>
-        </TabContainer>
-
-        <TabContainer style={{ display: activeTab === 2 ? 'block' : 'none' }}>
-          <Typography component="h6">Transactions</Typography>
-        </TabContainer>
-
-        <TabContainer style={{ display: activeTab === 3 ? 'block' : 'none' }}>
-          <Typography component="h6">Tools</Typography>
-        </TabContainer>
-
         <Typography
           component="div"
           classes={{ root: classes.fullWidth }}
@@ -108,7 +97,7 @@ class NavTabs extends React.Component {
             display: activeTab === 4 ? 'inherit' : 'none'
           }}
         >
-          <div style={{ marginTop: 50, width: '100%' }}>
+          <div style={{ width: '100%' }}>
             <WebviewTab />
           </div>
         </Typography>

--- a/src/components/Nodes/ClientConfig/VersionList.jsx
+++ b/src/components/Nodes/ClientConfig/VersionList.jsx
@@ -268,7 +268,7 @@ export default connect(mapStateToProps)(withStyles(styles)(VersionList))
 
 const StyledList = styled(List)`
   min-height: 200px;
-  max-height: calc(100vh - 295px);
+  max-height: calc(100vh - 235px);
   overflow-y: scroll;
 `
 

--- a/src/components/Nodes/ServicesNav.js
+++ b/src/components/Nodes/ServicesNav.js
@@ -18,7 +18,7 @@ const styles = theme => ({
   },
   content: {
     flexGrow: 1,
-    padding: `${theme.spacing.unit * 9}px ${theme.spacing.unit * 3}px ${theme
+    padding: `${theme.spacing.unit * 2}px ${theme.spacing.unit * 3}px ${theme
       .spacing.unit * 3}px`
   },
   toolbar: theme.mixins.toolbar
@@ -101,7 +101,6 @@ class ServicesTab extends Component {
           variant="permanent"
           classes={{ paper: classes.drawerPaper }}
         >
-          <div className={classes.toolbar} />
           <List>{this.renderServiceListItems()}</List>
         </Drawer>
         <main className={classes.content}>{children}</main>

--- a/src/components/Nodes/Terminal.jsx
+++ b/src/components/Nodes/Terminal.jsx
@@ -94,7 +94,7 @@ export default class Terminal extends Component {
 
             // Fluid width and height with support to scrolling
             width: 'calc(100vw - 310px)',
-            maxHeight: 'calc(100vh - 238px)',
+            maxHeight: 'calc(100vh - 188px)',
 
             // Scroll config
             overflowX: 'auto',


### PR DESCRIPTION
#### What does it do?
This experiment aims to simplify the UI. 

After a conversation with Alex, I removed the main tab bar to make the UI more straightforward. The sandbox could live right below the clients/services for now.

This also leans toward the mini window concept, depicted below.

#### Any helpful background information?

#### New dependencies? What are they used for?

#### Relevant screenshots?
![image](https://user-images.githubusercontent.com/47108/57101186-ace1b480-6cee-11e9-9aae-d8125cc503f2.png)

![image](https://user-images.githubusercontent.com/47108/57101356-0f3ab500-6cef-11e9-9d07-503df92a0bba.png)

