### PR TITLE
fix:  Material-UI "the key provided to the classes property is not implemened" warning

### DIFF
--- a/src/components/Nodes/ServicesNav.js
+++ b/src/components/Nodes/ServicesNav.js
@@ -56,11 +56,13 @@ class ServicesTab extends Component {
       selectedClientName
     } = this.props
 
+    const { content, drawer, drawerPaper, toolbar, ...restClasses } = classes
+
     return (
       <ServicesNavListItem
         key={client.name}
         client={client}
-        classes={classes}
+        classes={restClasses}
         handleToggle={handleToggle}
         handleSelectClient={handleSelectClient}
         isRunning={this.isRunning(client)}


### PR DESCRIPTION
Heya!

#### What does it do?
It eliminates unused classes from `classes` object for `ServicesNavListItem` component and resolves warnings of Material-UI which seen on screenshot.

#### Relevant screenshots?
<img width="1089" alt="Screenshot 2019-05-05 at 01 40 38" src="https://user-images.githubusercontent.com/2774845/57186069-f55cc600-6ed8-11e9-8942-b9ae1debd17c.png">
