### PR TITLE
fix: setState error when VersionListItem component already unmounted

### DIFF
--- a/src/components/Nodes/ClientConfig/VersionListItem.jsx
+++ b/src/components/Nodes/ClientConfig/VersionListItem.jsx
@@ -25,6 +25,15 @@ export default class VersionListItem extends Component {
     downloadProgress: 0
   }
 
+  componentDidMount() {
+    // @see https://reactjs.org/blog/2015/12/16/ismounted-antipattern.html
+    this._isMounted = true
+  }
+
+  componentWillUnmount() {
+    this._isMounted = false
+  }
+
   releaseDisplayName = release => {
     const { client } = this.props
     const { fileName } = release
@@ -58,12 +67,13 @@ export default class VersionListItem extends Component {
       let localRelease
       try {
         localRelease = await client.download(release, downloadProgress => {
-          this.setState({ downloadProgress })
+          if (this._isMounted) this.setState({ downloadProgress })
         })
       } catch (error) {
         handleDownloadError(error)
       }
-      this.setState({ isDownloading: false, downloadProgress: 0 })
+      if (this._isMounted)
+        this.setState({ isDownloading: false, downloadProgress: 0 })
       handleReleaseDownloaded(localRelease)
     })
   }


### PR DESCRIPTION
#### What does it do?
It prevents setState usage in VersionListItem component when the component is already unmounted. 
In following steps for user; 
1. clicks `download version button` 
2. changes the Services from side-tab before download ended. 

#### Relevant screenshots?
<img width="1089" alt="Screenshot 2019-05-05 at 03 05 59" src="https://user-images.githubusercontent.com/2774845/57187031-6906cf00-6ee9-11e9-8c47-816d504c6b56.png">

