### PR TITLE
fix: restore latest version warning

### DIFF
--- a/src/components/Nodes/ClientConfig/VersionList.jsx
+++ b/src/components/Nodes/ClientConfig/VersionList.jsx
@@ -154,17 +154,16 @@ class VersionList extends Component {
   }
 
   renderWarnings = () => {
-    // TODO:
-    // return <div>{this.renderLatestVersionWarning()}</div>
+    return <div>{this.renderLatestVersionWarning()}</div>
   }
 
   renderLatestVersionWarning = () => {
     const { classes, release } = this.props
     const { releases } = this.state
-    if (!release || !releases.length) {
+    if (!release.version || releases.length === 0) {
       return null
     }
-    const latestRelease = this.allReleases()[0]
+    const latestRelease = releases[0]
     const latestVersion = latestRelease.version
     const selectedVersion = release.version
     if (semver.compare(selectedVersion, latestVersion)) {

--- a/src/components/Nodes/ClientConfig/VersionList.jsx
+++ b/src/components/Nodes/ClientConfig/VersionList.jsx
@@ -158,7 +158,7 @@ class VersionList extends Component {
   }
 
   renderLatestVersionWarning = () => {
-    const { classes, release } = this.props
+    const { classes, release, client } = this.props
     const { releases } = this.state
     if (!release.version || releases.length === 0) {
       return null
@@ -173,8 +173,7 @@ class VersionList extends Component {
           message={
             <span>
               <WarningIcon classes={{ root: classes.warningIcon }} /> You are
-              using an older version of Geth ({selectedVersion})<br />
-              New releases contain performance and security enhancements.
+              using an older version of {client.displayName}
             </span>
           }
           action={
@@ -183,7 +182,7 @@ class VersionList extends Component {
                 this.handleReleaseSelect(latestRelease)
               }}
             >
-              Use {latestVersion}
+              Use {latestVersion.split('-')[0]}
             </Button>
           }
         />


### PR DESCRIPTION
#### What does it do?
Restores latest version error warning

Closes https://github.com/ethereum/grid/issues/208

<img width="791" alt="Screen Shot 2019-05-17 at 2 14 46 PM" src="https://user-images.githubusercontent.com/22116/57962964-85840d80-78d2-11e9-9389-f7580b54356f.png">
