### PR TITLE
feat: ErrorBoundary

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,6 +4,7 @@ import CssBaseline from '@material-ui/core/CssBaseline'
 import NavTabs from './NavTabs'
 import theme from '../theme'
 import HelpFab from './shared/HelpFab'
+import ErrorBoundary from './GenericErrorBoundary'
 
 export default class NewApp extends Component {
   static displayName = 'App'
@@ -16,7 +17,9 @@ export default class NewApp extends Component {
     return (
       <MuiThemeProvider theme={theme}>
         <CssBaseline />
-        <NavTabs />
+        <ErrorBoundary>
+          <NavTabs />
+        </ErrorBoundary>
         <HelpFab />
       </MuiThemeProvider>
     )

--- a/src/components/GenericErrorBoundary.js
+++ b/src/components/GenericErrorBoundary.js
@@ -1,0 +1,53 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { withStyles } from '@material-ui/core/styles'
+import Typography from '@material-ui/core/Typography'
+
+const styles = () => ({
+  stackTrace: {
+    fontFamily: 'monospace',
+    padding: '12px'
+  }
+})
+
+class ErrorBoundary extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+    classes: PropTypes.object
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error }
+  }
+
+  state = { error: null }
+
+  render() {
+    const { children, classes } = this.props
+    const { error } = this.state
+
+    if (error) {
+      return (
+        <StyledWrapper>
+          <Typography variant="h6">Whoops, something went wrong!</Typography>
+          <Typography>
+            If you would like to report this issue on GitHub, please include the
+            following stack trace:
+          </Typography>
+          <Typography classes={{ root: classes.stackTrace }}>
+            {error && error.stack}
+          </Typography>
+        </StyledWrapper>
+      )
+    }
+
+    return children
+  }
+}
+
+export default withStyles(styles)(ErrorBoundary)
+
+const StyledWrapper = styled.div`
+  padding: 12px;
+`

--- a/src/components/Nodes/ClientConfig/index.js
+++ b/src/components/Nodes/ClientConfig/index.js
@@ -12,6 +12,7 @@ import Terminal from '../Terminal'
 // import NodeInfo from '../NodeInfo'
 import { clearError } from '../../../store/client/actions'
 import Notification from '../../shared/Notification'
+import ErrorBoundary from '../../GenericErrorBoundary'
 
 function TabContainer(props) {
   const { children, style } = props
@@ -142,13 +143,15 @@ class ClientConfig extends Component {
         </TabContainer>
         {activeTab === 1 && (
           <TabContainer>
-            <DynamicConfigForm
-              clientName={client.name}
-              settings={settings}
-              handleClientConfigChanged={this.handleClientConfigChanged}
-              isClientRunning={isRunning}
-              clientConfigChanged={clientConfigChanged}
-            />
+            <ErrorBoundary>
+              <DynamicConfigForm
+                clientName={client.name}
+                settings={settings}
+                handleClientConfigChanged={this.handleClientConfigChanged}
+                isClientRunning={isRunning}
+                clientConfigChanged={clientConfigChanged}
+              />
+            </ErrorBoundary>
           </TabContainer>
         )}
         <TabContainer style={{ display: activeTab === 2 ? 'block' : 'none' }}>

--- a/src/store/client/actions.js
+++ b/src/store/client/actions.js
@@ -39,14 +39,18 @@ function removeListeners(client) {
 }
 
 const getPluginSettings = c => {
-  return ((c.plugin || {}).config || {}).settings || {}
+  try {
+    const settings = c.plugin.config.settings // eslint-disable-line
+    return Array.isArray(settings) ? settings : []
+  } catch (e) {
+    return []
+  }
 }
 
 const getClientDefaults = client => {
   const pluginDefaults = {}
 
   const clientSettings = getPluginSettings(client)
-  if (!clientSettings) return {}
 
   clientSettings.forEach(i => {
     if ('default' in i) {
@@ -59,8 +63,8 @@ const getClientDefaults = client => {
 export const initClient = client => {
   return dispatch => {
     const clientData = client.plugin.config
+    const config = getClientDefaults(client)
 
-    const config = clientData.config ? getClientDefaults(client) : {}
     dispatch({
       type: 'CLIENT:INIT',
       payload: {


### PR DESCRIPTION
#### What does it do?
- Introduces GenericErrorBoundary and adds boundaries at the app level and at the DynaminConfigForm.
- Fixes a bug that occurs when a service (e.g. Raiden) has settings of object data type instead of array.
#### Any helpful background information?
- Waiting on the hardcoded geth PR to implement proper error display.
- Future work could make `ErrorBoundary` component more fun or instructive.
#### Relevant screenshots?
Top-level boundary:
![Screen Shot 2019-05-20 at 1 29 04 PM](https://user-images.githubusercontent.com/3621728/58051696-201d6000-7b10-11e9-8fd2-250abc264d44.png)
DynamicConfigForm-level boundary:
![Screen Shot 2019-05-20 at 1 19 18 PM](https://user-images.githubusercontent.com/3621728/58051724-33303000-7b10-11e9-891f-9e30c570ef75.png)

#### Does it close any issues?
- Closes https://github.com/ethereum/grid/issues/211