### PR TITLE
fix: fab behind scrollbar

### DIFF
--- a/src/components/shared/HelpFab.js
+++ b/src/components/shared/HelpFab.js
@@ -13,7 +13,12 @@ class HelpFab extends React.Component {
       <Fab
         onClick={this.handleButtonClick}
         color="primary"
-        style={{ position: 'fixed', right: 20, bottom: 20 }}
+        style={{
+          position: 'fixed',
+          right: 20,
+          bottom: 20,
+          transform: 'translate3d(0, 0, 0)'
+        }}
       >
         <FeedbackIcon />
       </Fab>


### PR DESCRIPTION
#### What does it do?
Implements css fix/hack to keep the feedback btn above the scrollbar.
#### Any helpful background information?
Reproducing this bug has been unreliable, but it reared its head again. This seems to do the trick.
#### Relevant screenshots?
Before:
![Screen Shot 2019-05-21 at 9 58 29 AM](https://user-images.githubusercontent.com/3621728/58114794-c2dbea00-7bb5-11e9-8e5b-7b63a2b3bbb6.png)
After:
![Screen Shot 2019-05-21 at 10 42 40 AM](https://user-images.githubusercontent.com/3621728/58114813-cff8d900-7bb5-11e9-9b95-1bf00f76148e.png)

#### Does it close any issues?
Closes https://github.com/ethereum/grid/issues/197