### PR TITLE
feat: add app view

### DIFF
--- a/src/components/Apps/AppItem.js
+++ b/src/components/Apps/AppItem.js
@@ -1,0 +1,65 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { withStyles } from '@material-ui/core/styles'
+import Card from '@material-ui/core/Card'
+import CardHeader from '@material-ui/core/CardHeader'
+import CardContent from '@material-ui/core/CardContent'
+import CardMedia from '@material-ui/core/CardMedia'
+import CardActions from '@material-ui/core/CardActions'
+import Button from '@material-ui/core/Button'
+import Typography from '@material-ui/core/Typography'
+import moment from 'moment'
+import Grid from '../../API/Grid'
+
+const styles = {
+  card: {
+    minWidth: 275
+  },
+  media: {
+    height: 0,
+    paddingTop: '56.25%' // 16:9
+  },
+  title: {
+    fontSize: 14
+  }
+}
+
+class AppItem extends React.Component {
+  static propTypes = {
+    classes: PropTypes.object.isRequired,
+    app: PropTypes.object
+  }
+
+  state = {}
+
+  handleAppLaunch = () => {
+    const { app } = this.props
+    Grid.AppManager.launch(app)
+  }
+
+  render() {
+    const { classes, app } = this.props
+
+    const { name, lastUpdated, description, screenshot } = app
+
+    return (
+      <Card className={classes.card}>
+        <CardHeader
+          title={name}
+          subheader={moment(lastUpdated).format('MMMM Do YYYY')}
+        />
+        <CardMedia className={classes.media} image={screenshot} />
+        <CardContent>
+          <Typography component="p">{description}</Typography>
+        </CardContent>
+        <CardActions>
+          <Button size="small" onClick={this.handleAppLaunch}>
+            Launch
+          </Button>
+        </CardActions>
+      </Card>
+    )
+  }
+}
+
+export default withStyles(styles)(AppItem)

--- a/src/components/Apps/index.js
+++ b/src/components/Apps/index.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import Grid from '@material-ui/core/Grid'
+import AppItem from './AppItem'
+import GridAPI from '../../API/Grid'
+
+class AppsOverview extends React.Component {
+  state = {}
+
+  render() {
+    const apps = GridAPI.AppManager ? GridAPI.AppManager.getAvailableApps() : []
+
+    return (
+      <div style={{ width: '100%' }}>
+        <Grid container spacing={24}>
+          {apps.length ? (
+            apps.map(app => (
+              <Grid item xs={4} key={app.name}>
+                <AppItem app={app} />
+              </Grid>
+            ))
+          ) : (
+            <span>no apps found</span>
+          )}
+        </Grid>
+      </div>
+    )
+  }
+}
+
+export default AppsOverview

--- a/src/components/NavTabs.js
+++ b/src/components/NavTabs.js
@@ -7,7 +7,7 @@ import Typography from '@material-ui/core/Typography'
 import Tab from '@material-ui/core/Tab'
 import Tabs from '@material-ui/core/Tabs'
 import NodesTab from './Nodes'
-import WebviewTab from './Webview'
+import AppsTab from './Apps'
 
 const styles = theme => ({
   root: {
@@ -68,14 +68,7 @@ class NavTabs extends React.Component {
             indicatorColor="primary"
           >
             <Tab label="Nodes" data-test-id="navbar-item-nodes" />
-            <Tab label="Network" data-test-id="navbar-item-network" disabled />
-            <Tab
-              label="Transactions"
-              data-test-id="navbar-item-transactions"
-              disabled
-            />
-            <Tab label="Tools" data-test-id="navbar-item-tools" disabled />
-            <Tab label="Webview" data-test-id="navbar-item-webview" />
+            <Tab label="Apps" data-test-id="navbar-item-apps" />
           </Tabs>
         </AppBar>
 
@@ -90,28 +83,10 @@ class NavTabs extends React.Component {
         </Typography>
 
         <TabContainer style={{ display: activeTab === 1 ? 'block' : 'none' }}>
-          <Typography component="h6">Network</Typography>
-        </TabContainer>
-
-        <TabContainer style={{ display: activeTab === 2 ? 'block' : 'none' }}>
-          <Typography component="h6">Transactions</Typography>
-        </TabContainer>
-
-        <TabContainer style={{ display: activeTab === 3 ? 'block' : 'none' }}>
-          <Typography component="h6">Tools</Typography>
-        </TabContainer>
-
-        <Typography
-          component="div"
-          classes={{ root: classes.fullWidth }}
-          style={{
-            display: activeTab === 4 ? 'inherit' : 'none'
-          }}
-        >
           <div style={{ marginTop: 50, width: '100%' }}>
-            <WebviewTab />
+            <AppsTab />
           </div>
-        </Typography>
+        </TabContainer>
       </div>
     )
   }

--- a/src/components/Webview/UrlBar.jsx
+++ b/src/components/Webview/UrlBar.jsx
@@ -82,13 +82,16 @@ class CustomizedInputBase extends React.Component {
           <ArrowIcon />
         </IconButton>
         <Divider className={classes.divider} />
+        {/*
         <Button
           onClick={() =>
-            this.navigate('package://github.com/ethereum/remix-ide')
+            // this.navigate('package://github.com/ethereum/remix-ide')
+            this.navigate('package://24f0c0e4272ca1bbb7e32fe1d8bf87367b169f74415e48eb9f2ca4552759ef5c')
           }
         >
           Remix IDE
         </Button>
+         */}
         <Divider className={classes.divider} />
         <IconButton onClick={() => onOpenDevTools()}>
           <BuildIcon />

--- a/src/components/Webview/UrlBar.jsx
+++ b/src/components/Webview/UrlBar.jsx
@@ -5,7 +5,6 @@ import Paper from '@material-ui/core/Paper'
 import InputBase from '@material-ui/core/InputBase'
 import Divider from '@material-ui/core/Divider'
 import IconButton from '@material-ui/core/IconButton'
-import Button from '@material-ui/core/Button'
 import ArrowIcon from '@material-ui/icons/ArrowForward'
 import BuildIcon from '@material-ui/icons/Build'
 

--- a/src/components/Webview/index.jsx
+++ b/src/components/Webview/index.jsx
@@ -1,16 +1,31 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import UrlBar from './UrlBar'
 
 class Webview extends React.Component {
+  static propTypes = {
+    url: PropTypes.string
+  }
+
   state = {
-    currentUrl: 'http://localhost:3000'
+    currentUrl: 'http://localhost:3000',
+    showUrlBar: true
   }
 
   componentDidMount() {
+    const { url } = this.props
+    const { currentUrl } = this.state
     const { webview } = this
     webview.addEventListener('will-navigate', this.handleWillNavigate)
     webview.addEventListener('ipc-message', this.handleIpcMessage)
     webview.addEventListener('dom-ready', this.handleDomReady)
+    if (url) {
+      this.setState({
+        currentUrl: url,
+        // if url is localhost:3000 -> "dev app" -> show url bar
+        showUrlBar: url === currentUrl
+      })
+    }
   }
 
   componentWillUnmount() {
@@ -50,13 +65,15 @@ class Webview extends React.Component {
   }
 
   render() {
-    const { currentUrl } = this.state
+    const { currentUrl, showUrlBar } = this.state
     return (
       <div style={{ width: '100%' }}>
-        <UrlBar
-          onOpenDevTools={this.openDevTools}
-          onNavigate={this.handleNavigate}
-        />
+        {showUrlBar && (
+          <UrlBar
+            onOpenDevTools={this.openDevTools}
+            onNavigate={this.handleNavigate}
+          />
+        )}
         <div style={{ width: '100%', marginTop: 10 }}>
           <webview
             ref={ref => {

--- a/src/index.js
+++ b/src/index.js
@@ -5,8 +5,9 @@ import { Provider } from 'react-redux'
 // import { PersistGate } from 'redux-persist/integration/react'
 import App from './components/App'
 import Popup from './components/popups'
-import { Mist } from './API'
+import { Grid } from './API'
 import configureStore from './store'
+import Webview from './components/Webview'
 // import Spinner from './components/shared/Spinner'
 
 const { store /* , persistor */ } = configureStore()
@@ -33,29 +34,39 @@ const root = document.getElementById('root')
 const urlParams = getUrlVars()
 const popupName = urlParams.name
 
-const args = Mist.window.getArgs()
-switch (urlParams.app) {
-  case 'popup':
-    store.dispatch({
-      type: 'SET_TX',
-      payload: args
-    })
-    ReactDOM.render(
-      <Provider store={store}>
-        <Popup name={popupName} popup={{ args }} />
-      </Provider>,
-      root
-    )
-    break
-  case undefined:
-  default:
-    ReactDOM.render(
-      <Provider store={store}>
-        {/* <PersistGate loading={<Spinner />} persistor={persistor}> */}
-        <App />
-        {/* </PersistGate> */}
-      </Provider>,
-      root
-    )
-    break
+const args = Grid.window.getArgs() || {}
+
+if (args.isApp) {
+  ReactDOM.render(
+    <Provider store={store}>
+      <Webview url={args.url} />
+    </Provider>,
+    root
+  )
+} else {
+  switch (urlParams.app) {
+    case 'popup':
+      store.dispatch({
+        type: 'SET_TX',
+        payload: args
+      })
+      ReactDOM.render(
+        <Provider store={store}>
+          <Popup name={popupName} popup={{ args }} />
+        </Provider>,
+        root
+      )
+      break
+    case undefined:
+    default:
+      ReactDOM.render(
+        <Provider store={store}>
+          {/* <PersistGate loading={<Spinner />} persistor={persistor}> */}
+          <App />
+          {/* </PersistGate> */}
+        </Provider>,
+        root
+      )
+      break
+  }
 }


### PR DESCRIPTION
#### What does it do?

Restructures the UI in Nodes and Apps. Available apps are fetched from Grid API (needs changes in Grid to find apps).

It removes disabled & unused tabs. The webview tab is refactored into a "popup" / container window used to display launched apps. 

#### Any helpful background information?

- the UI becomes cleaner and the concepts easier to understand (no webview tab -> "no browser")
- easier for users to try out apps that make use of the clients
- easier for us to showcase examples and motivate projects
- challenges our architecture to think about two different flows:
1. user wants to configure and start clients as main objective
2. user wants an app that communicate with clients (more UX focused and likely?)

-> apps will eventually be able to define a dependency to clients which are automatically configured and started

Allows us to remove complex logic from the core (such as Clef UI) and keep Grid lightweight and easier to maintain. Helps apps such as Remix or Clef to be recognized as standalone apps.

#### New dependencies? What are they used for?

Needs the new AppManager Grid API to load a list of apps and launch apps.

#### Relevant screenshots?

![image](https://user-images.githubusercontent.com/4280481/58162112-cf2d7900-7c81-11e9-8a66-1bdd0eb8d70f.png)

![image](https://user-images.githubusercontent.com/4280481/58162322-4531e000-7c82-11e9-8b51-1a139b189671.png)

#### Does it close any issues?
