### PR TITLE
fix: feedback btn cover app launch btn

### DIFF
--- a/src/components/Apps/index.js
+++ b/src/components/Apps/index.js
@@ -10,7 +10,7 @@ class AppsOverview extends React.Component {
     const apps = GridAPI.AppManager ? GridAPI.AppManager.getAvailableApps() : []
 
     return (
-      <div style={{ width: '100%' }}>
+      <div style={{ width: '100%', paddingBottom: '64px' }}>
         <Grid container spacing={24}>
           {apps.length ? (
             apps.map(app => (


### PR DESCRIPTION
#### What does it do?
Adds some padding so the feedback button doesn't cover the launch button of the corner app.

#### Relevant screenshots?
before:
![Screen Shot 2019-06-03 at 8 51 21 AM](https://user-images.githubusercontent.com/3621728/58811768-a68c7400-85dd-11e9-8400-b4c1999a849b.png)

after:
![Screen Shot 2019-06-03 at 8 56 12 AM](https://user-images.githubusercontent.com/3621728/58811776-aab89180-85dd-11e9-8ae9-26ada27ddeda.png)

#### Does it close any issues?
closes https://github.com/ethereum/grid/issues/239