### PR TITLE
fix: preserves spaces on flag values

### DIFF
--- a/src/components/Nodes/ServicesNavListItem.js
+++ b/src/components/Nodes/ServicesNavListItem.js
@@ -67,6 +67,7 @@ class ServicesNavListItem extends Component {
           selected: classes.selected
         }}
         button
+        data-test-id={`node-${client.name}`}
       >
         <ListItemText
           primary={client.displayName}

--- a/src/lib/flags.js
+++ b/src/lib/flags.js
@@ -1,0 +1,48 @@
+/**
+ * This method preserves spaces contained in the value.
+ * input: "--ipc '%s'", "/path with spaces"
+ * output: ["--ipc", "/path with spaces"]
+ */
+const parseFlag = (pattern, value) => {
+  let result = pattern.split(' ').map(e => e.replace(/%s/, value))
+
+  return result
+}
+
+export const generateFlags = (userConfig, nodeSettings) => {
+  if (!Array.isArray(nodeSettings))
+    throw new Error('Settings must be an Array instance')
+
+  const userConfigEntries = Object.keys(userConfig)
+  let flags = []
+
+  userConfigEntries.forEach(entry => {
+    let pattern
+    let configEntry = nodeSettings.find(setting => setting.id === entry)
+    let flagString = configEntry.flag
+
+    if (flagString) {
+      pattern = flagString
+    } else if (configEntry.options) {
+      const options = configEntry.options
+      const selectedOption = options.find(
+        option =>
+          userConfig[entry] === option.value || userConfig[entry] === option
+      )
+      if (typeof selectedOption['flag'] !== 'string') {
+        throw new Error(
+          `Option "${selectedOption.value ||
+            selectedOption}" must have the "flag" key`
+        )
+      }
+      pattern = selectedOption.flag
+    } else {
+      throw new Error(`Config entry "${entry}" must have the "flag" key`)
+    }
+
+    const parsedFlag = parseFlag(pattern, userConfig[entry])
+    flags = flags.concat(parsedFlag)
+  })
+
+  return flags.filter(flag => flag.length > 0)
+}

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -40,38 +40,3 @@ export const getPluginSettingsConfig = client => {
     return []
   }
 }
-
-export const generateFlags = (userConfig, nodeSettings) => {
-  if (!Array.isArray(nodeSettings))
-    throw new Error('Settings must be an Array instance')
-  const userConfigEntries = Object.keys(userConfig)
-  let flags = []
-
-  userConfigEntries.forEach(entry => {
-    let flag
-    let configEntry = nodeSettings.find(setting => setting.id === entry)
-    let flagString = configEntry.flag
-
-    if (flagString) {
-      flag = flagString.replace(/%s/, userConfig[entry]).split(' ')
-    } else if (configEntry.options) {
-      const options = configEntry.options
-      const selectedOption = options.find(
-        option =>
-          userConfig[entry] === option.value || userConfig[entry] === option
-      )
-      if (typeof selectedOption['flag'] !== 'string') {
-        throw new Error(
-          `Option "${selectedOption.value ||
-            selectedOption}" must have the "flag" key`
-        )
-      }
-      flag = selectedOption.flag.replace(/%s/, userConfig[entry]).split(' ')
-    } else {
-      throw new Error(`Config entry "${entry}" must have the "flag" key`)
-    }
-    flags = flags.concat(flag)
-  })
-
-  return flags.filter(flag => flag.length > 0)
-}

--- a/src/store/client/actions.js
+++ b/src/store/client/actions.js
@@ -1,5 +1,6 @@
 import ClientService from './clientService'
-import { generateFlags, getPluginSettingsConfig } from '../../lib/utils'
+import { getPluginSettingsConfig } from '../../lib/utils'
+import { generateFlags } from '../../lib/flags'
 
 export const onConnectionUpdate = (clientName, status) => {
   return { type: 'CLIENT:STATUS_UPDATE', payload: { clientName, status } }

--- a/src/test/settings.test.js
+++ b/src/test/settings.test.js
@@ -149,12 +149,12 @@ describe('generateFlags', () => {
     const settings = [
       {
         id: 'ipcPath',
-        flag: '--ipc "%s"'
+        flag: '--ipc %s'
       }
     ]
 
     const flags = generateFlags(input, settings)
-    expect(flags).toEqual(['--ipc', '"/path/with spaces.ipc"'])
+    expect(flags).toEqual(['--ipc', '/path/with spaces.ipc'])
   })
 })
 

--- a/src/test/settings.test.js
+++ b/src/test/settings.test.js
@@ -1,4 +1,5 @@
-import { getPluginSettingsConfig, generateFlags } from '../lib/utils'
+import { getPluginSettingsConfig } from '../lib/utils'
+import { generateFlags } from '../lib/flags'
 
 describe('getPluginSettingsConfig', () => {
   it('returns an empty array if no client', () => {
@@ -141,6 +142,19 @@ describe('generateFlags', () => {
 
     const flags = generateFlags(input, settings)
     expect(flags).toEqual(['--syncmode', 'light', '--maxpeers=100'])
+  })
+
+  it('should not split values with spaces', () => {
+    const input = { ipcPath: '/path/with spaces.ipc' }
+    const settings = [
+      {
+        id: 'ipcPath',
+        flag: '--ipc "%s"'
+      }
+    ]
+
+    const flags = generateFlags(input, settings)
+    expect(flags).toEqual(['--ipc', '"/path/with spaces.ipc"'])
   })
 })
 


### PR DESCRIPTION
#### What does it do?

- extracts `generateFlags()` to a new file
- preserves spaces typed by users 
- [test case covering expected flag values with spaces preserved](https://github.com/ethereum/grid-ui/pull/83/files#diff-aff35ec90e4353a3a88190d9356c3185R157)

#### Does it close any issues?
Closes https://github.com/ethereum/grid/issues/236