### PR TITLE
ci: nightly builds only on weekdays

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,7 @@ workflows:
   nightly:
     triggers:
       - schedule:
-          cron: "0 0 * * *"
+          cron: "0 0 * * 1-5"
           filters:
             branches:
               only:


### PR DESCRIPTION
#### What does it do?

aims to lower the amount of nightly builds being published.
