### PR TITLE
ci: disabling nightly builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,30 +24,9 @@ jobs:
       - store_artifacts:
           path: build/manifest.json
 
-  build-nightly:
-    docker:
-      - image: circleci/node:10.5
-    steps:
-      - checkout
-      - run: yarn
-      - run: CI=false yarn deploy nightly
-      - store_artifacts:
-          path: build/grid-ui*.zip
-      - store_artifacts:
-          path: build/manifest.json
 
 workflows:
   version: 2
   commit:
     jobs:
       - build
-  nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - dev
-    jobs:
-      - build-nightly


### PR DESCRIPTION
#### What does it do?

removes nightly builds, to alleviate the amount of versions being released everyday.