### PR TITLE
fix: height 100% for apps

### DIFF
--- a/src/components/Webview/index.jsx
+++ b/src/components/Webview/index.jsx
@@ -67,23 +67,22 @@ class Webview extends React.Component {
   render() {
     const { currentUrl, showUrlBar } = this.state
     return (
-      <div style={{ width: '100%' }}>
+      <div style={{ width: '100%', height: '100%' }}>
         {showUrlBar && (
           <UrlBar
             onOpenDevTools={this.openDevTools}
             onNavigate={this.handleNavigate}
           />
         )}
-        <div style={{ width: '100%', marginTop: 10 }}>
+        <div style={{ width: '100%', height: '100%' }}>
           <webview
             ref={ref => {
               this.webview = ref
             }}
             src={currentUrl}
             style={{
-              display: 'inline-flex',
               width: '100%',
-              height: 'calc(100vh - 100px)'
+              height: '100%'
             }}
           />
         </div>

--- a/src/components/Webview/index.jsx
+++ b/src/components/Webview/index.jsx
@@ -74,7 +74,12 @@ class Webview extends React.Component {
             onNavigate={this.handleNavigate}
           />
         )}
-        <div style={{ width: '100%', height: '100%' }}>
+        <div
+          style={{
+            width: '100%',
+            height: showUrlBar ? 'calc(100% - 52px)' : '100%'
+          }}
+        >
           <webview
             ref={ref => {
               this.webview = ref

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,13 @@
+html {
+  height: 100%;
+}
+
 body {
+  height: 100%;
   padding: 0;
   margin: 0;
+}
+
+#root {
+  height: 100%;
 }


### PR DESCRIPTION
#### What does it do?
Fixes apps to show in their window with height:100%;

#### Before:
<img src="https://user-images.githubusercontent.com/47108/59618984-71147a00-90f7-11e9-8b6f-73b26862af24.png">

#### After:
<img width="1062" alt="Screen Shot 2019-06-17 at 2 19 43 PM" src="https://user-images.githubusercontent.com/22116/59637613-17b64600-910b-11e9-95d7-5830a0c2bc05.png">
