### PR TITLE
feat: expands showOpenDialog to accept `file` or `directory`

### DIFF
--- a/src/components/Nodes/ClientConfig/DynamicConfigForm/FormItem.jsx
+++ b/src/components/Nodes/ClientConfig/DynamicConfigForm/FormItem.jsx
@@ -36,19 +36,26 @@ class DynamicConfigFormItem extends Component {
     this.updateRedux.cancel()
   }
 
-  browseDir = key => async event => {
-    const { openFolderDialog } = GridAPI
-    // If we don't have openFolderDialog from Grid,
+  showOpenDialog = key => async event => {
+    const { showOpenDialog } = GridAPI
+    // If we don't have showOpenDialog from Grid,
     // return true to continue with native file dialog
-    if (!openFolderDialog) {
+    if (!showOpenDialog) {
       return true
     }
+    // Continue with Grid.showOpenDialog()
     event.preventDefault()
-    // Continue with Grid.openFolderDialog()
-    const { client, clientName } = this.props
+    const { client, clientName, item } = this.props
+    const { type } = item
     const defaultPath = client[clientName].config[key]
-    const dir = await openFolderDialog(defaultPath)
-    this.handleChange(key, dir)
+    const openDirectory = type.includes('directory')
+    const selectMultiple = type.includes('multiple')
+    const path = await showOpenDialog(
+      openDirectory,
+      selectMultiple,
+      defaultPath
+    )
+    this.handleChange(key, path)
     return null
   }
 
@@ -102,7 +109,10 @@ class DynamicConfigFormItem extends Component {
             />
           </div>
         )
-      case 'path':
+      case 'file':
+      case 'file_multiple':
+      case 'directory':
+      case 'directory_multiple':
         return (
           <div>
             <TextField
@@ -117,7 +127,7 @@ class DynamicConfigFormItem extends Component {
                   <InputAdornment position="end">
                     <IconButton
                       disabled={isClientRunning}
-                      aria-label="Open folder browser"
+                      aria-label="Show Open Dialog"
                       onClick={() => {
                         if (
                           this.inputOpenFileRef &&
@@ -136,15 +146,16 @@ class DynamicConfigFormItem extends Component {
             />
             <input
               type="file"
-              id="open-file-dialog"
+              id="show-open-dialog"
               onChange={event =>
                 this.handleChange(itemKey, event.target.files[0].path)
               }
-              onClick={this.browseDir(itemKey)}
+              onClick={this.showOpenDialog(itemKey)}
               ref={this.inputOpenFileRef}
               style={{ display: 'none' }}
-              webkitdirectory="true"
-              directory="true"
+              webkitdirectory={type.includes('directory')}
+              directory={type.includes('directory')}
+              multiple={type.includes('multiple')}
             />
           </div>
         )

--- a/src/components/Nodes/ClientConfig/DynamicConfigForm/FormItem.jsx
+++ b/src/components/Nodes/ClientConfig/DynamicConfigForm/FormItem.jsx
@@ -48,13 +48,9 @@ class DynamicConfigFormItem extends Component {
     const { client, clientName, item } = this.props
     const { type } = item
     const defaultPath = client[clientName].config[key]
-    const openDirectory = type.includes('directory')
+    const pathType = type.replace('_multiple', '')
     const selectMultiple = type.includes('multiple')
-    const path = await showOpenDialog(
-      openDirectory,
-      selectMultiple,
-      defaultPath
-    )
+    const path = await showOpenDialog(pathType, selectMultiple, defaultPath)
     this.handleChange(key, path)
     return null
   }

--- a/src/components/Nodes/ClientConfig/DynamicConfigForm/FormItem.jsx
+++ b/src/components/Nodes/ClientConfig/DynamicConfigForm/FormItem.jsx
@@ -153,9 +153,9 @@ class DynamicConfigFormItem extends Component {
               onClick={this.showOpenDialog(itemKey)}
               ref={this.inputOpenFileRef}
               style={{ display: 'none' }}
-              webkitdirectory={type.includes('directory')}
-              directory={type.includes('directory')}
-              multiple={type.includes('multiple')}
+              webkitdirectory={type.includes('directory') ? 1 : 0}
+              directory={type.includes('directory') ? 1 : 0}
+              multiple={type.includes('multiple') ? 1 : 0}
             />
           </div>
         )


### PR DESCRIPTION
Renames `openFolderDialog` to `showOpenDialog` and accepts `file` or `directory` (or `file_multiple` or `directory_multiple`)

Pairs with https://github.com/ethereum/grid/pull/286