### PR TITLE
feat: persist config data

### DIFF
--- a/src/components/Nodes/index.js
+++ b/src/components/Nodes/index.js
@@ -9,6 +9,7 @@ import {
   setConfig,
   toggleClient
 } from '../../store/client/actions'
+import { getPersistedClientSelection } from '../../lib/utils'
 
 import Grid from '../../API/Grid'
 
@@ -34,11 +35,12 @@ class NodesTab extends Component {
   initClients = clients => {
     const { clientState, dispatch } = this.props
 
-    // Sync clients with redux
+    // Sync clients with Redux
     clients.map(client => dispatch(initClient(client)))
 
-    // Set the selected client if Redux out of sync
+    // Set the selected client from config.json or a fallback method
     const selectedClient =
+      clients.find(client => client.name === getPersistedClientSelection()) ||
       clients.find(client => client.name === clientState.selected) ||
       clients.find(client => client.order === 1) ||
       clients[0]

--- a/src/components/Nodes/index.js
+++ b/src/components/Nodes/index.js
@@ -32,14 +32,16 @@ class NodesTab extends Component {
   }
 
   initClients = clients => {
-    const { dispatch } = this.props
+    const { clientState, dispatch } = this.props
 
     // Sync clients with redux
     clients.map(client => dispatch(initClient(client)))
 
-    // Set the selected client
+    // Set the selected client if Redux out of sync
     const selectedClient =
-      clients.find(client => client.order === 1) || clients[0]
+      clients.find(client => client.name === clientState.selected) ||
+      clients.find(client => client.order === 1) ||
+      clients[0]
     this.handleSelectClient(selectedClient)
 
     // TODO: two sources of truth - local and redux state

--- a/src/index.js
+++ b/src/index.js
@@ -2,15 +2,13 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import './index.css'
 import { Provider } from 'react-redux'
-import { PersistGate } from 'redux-persist/integration/react'
 import App from './components/App'
 import Popup from './components/popups'
 import { Grid } from './API'
 import configureStore from './store'
 import Webview from './components/Webview'
-import Spinner from './components/shared/Spinner'
 
-const { store, persistor } = configureStore()
+const store = configureStore()
 
 // see https://github.com/facebook/create-react-app/issues/1084#issuecomment-273272872
 // Copied from http:jquery-howto.blogspot.com/2009/09/get-url-parameters-values-with-jquery.html
@@ -61,9 +59,7 @@ if (args.isApp) {
     default:
       ReactDOM.render(
         <Provider store={store}>
-          <PersistGate loading={<Spinner />} persistor={persistor}>
-            <App />
-          </PersistGate>
+          <App />
         </Provider>,
         root
       )

--- a/src/index.js
+++ b/src/index.js
@@ -2,15 +2,15 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import './index.css'
 import { Provider } from 'react-redux'
-// import { PersistGate } from 'redux-persist/integration/react'
+import { PersistGate } from 'redux-persist/integration/react'
 import App from './components/App'
 import Popup from './components/popups'
 import { Grid } from './API'
 import configureStore from './store'
 import Webview from './components/Webview'
-// import Spinner from './components/shared/Spinner'
+import Spinner from './components/shared/Spinner'
 
-const { store /* , persistor */ } = configureStore()
+const { store, persistor } = configureStore()
 
 // see https://github.com/facebook/create-react-app/issues/1084#issuecomment-273272872
 // Copied from http:jquery-howto.blogspot.com/2009/09/get-url-parameters-values-with-jquery.html
@@ -61,9 +61,9 @@ if (args.isApp) {
     default:
       ReactDOM.render(
         <Provider store={store}>
-          {/* <PersistGate loading={<Spinner />} persistor={persistor}> */}
-          <App />
-          {/* </PersistGate> */}
+          <PersistGate loading={<Spinner />} persistor={persistor}>
+            <App />
+          </PersistGate>
         </Provider>,
         root
       )

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -61,11 +61,20 @@ export const getSettingsIds = client => {
   }
 }
 
-export const getClientPersistedSettings = clientName => {
+export const getPersistedClientSettings = clientName => {
   try {
     const settings = Grid.Config.getItem('settings')
     return settings[clientName] || {}
   } catch (e) {
     return {}
+  }
+}
+
+export const getPersistedClientSelection = () => {
+  try {
+    const settings = Grid.Config.getItem('settings')
+    return settings.selected || ''
+  } catch (e) {
+    return ''
   }
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -40,3 +40,14 @@ export const getPluginSettingsConfig = client => {
     return []
   }
 }
+
+export const getDefaultSetting = (client, id) => {
+  try {
+    const setting = client.plugin.config.settings.find(
+      setting => setting.id === id
+    )
+    return setting.default
+  } catch (e) {
+    return ''
+  }
+}

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Grid } from '../API'
 
 // calling styled(without('unneededProp')(TheComponent))
 // helps satisfy error of extra StyledComponents props passing into children
@@ -49,5 +50,22 @@ export const getDefaultSetting = (client, id) => {
     return setting.default
   } catch (e) {
     return ''
+  }
+}
+
+export const getSettingsIds = client => {
+  try {
+    return client.plugin.config.settings.map(setting => setting.id)
+  } catch (e) {
+    return []
+  }
+}
+
+export const getClientPersistedSettings = clientName => {
+  try {
+    const settings = Grid.Config.getItem('settings')
+    return settings[clientName] || {}
+  } catch (e) {
+    return {}
   }
 }

--- a/src/store/client/actions.js
+++ b/src/store/client/actions.js
@@ -1,6 +1,6 @@
 import ClientService from './clientService'
 import {
-  getClientPersistedSettings,
+  getPersistedClientSettings,
   getDefaultSetting,
   getPluginSettingsConfig,
   getSettingsIds
@@ -16,7 +16,7 @@ const buildClientDefaults = client => {
   const settingsIds = getSettingsIds(client)
 
   // Handle rehydration: if config.json has settings already, use them.
-  const persistedSettings = getClientPersistedSettings(client.name)
+  const persistedSettings = getPersistedClientSettings(client.name)
   if (settingsIds.length && persistedSettings) {
     if (Object.keys(persistedSettings).length) {
       settingsIds.forEach(id => {
@@ -45,8 +45,7 @@ export const getGeneratedFlags = (client, config) => {
 
 export const initClient = client => {
   return dispatch => {
-    // const reduxClientState = getState().client[client.name]
-    const config = buildClientDefaults(client /* , reduxClientState */)
+    const config = buildClientDefaults(client)
     const clientData = client.plugin.config
     const flags = getGeneratedFlags(client, config)
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -2,6 +2,7 @@ import { createStore, applyMiddleware } from 'redux'
 import { persistStore } from 'redux-persist'
 import { composeWithDevTools } from 'remote-redux-devtools'
 import thunk from 'redux-thunk'
+import { saveSettings } from './middleware'
 import persistedReducer from './rootReducer'
 
 // In development, send Redux actions to a local DevTools server
@@ -18,7 +19,7 @@ if (process.env.NODE_ENV === 'development') {
 export default function configureStore() {
   const store = createStore(
     persistedReducer,
-    debugWrapper(applyMiddleware(thunk))
+    debugWrapper(applyMiddleware(thunk, saveSettings))
   )
   const persistor = persistStore(store)
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,5 +1,5 @@
 import { createStore, applyMiddleware } from 'redux'
-// import { persistStore } from 'redux-persist'
+import { persistStore } from 'redux-persist'
 import { composeWithDevTools } from 'remote-redux-devtools'
 import thunk from 'redux-thunk'
 import persistedReducer from './rootReducer'
@@ -20,7 +20,7 @@ export default function configureStore() {
     persistedReducer,
     debugWrapper(applyMiddleware(thunk))
   )
-  // const persistor = persistStore(store)
+  const persistor = persistStore(store)
 
   if (module.hot) {
     module.hot.accept('./rootReducer', () => {
@@ -29,5 +29,5 @@ export default function configureStore() {
     })
   }
 
-  return { store /* , persistor */ }
+  return { store, persistor }
 }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,9 +1,8 @@
 import { createStore, applyMiddleware } from 'redux'
-import { persistStore } from 'redux-persist'
 import { composeWithDevTools } from 'remote-redux-devtools'
 import thunk from 'redux-thunk'
 import { saveSettings } from './middleware'
-import persistedReducer from './rootReducer'
+import rootReducer from './rootReducer'
 
 // In development, send Redux actions to a local DevTools server
 // Note: run and view these DevTools with `yarn dev:tools`
@@ -18,10 +17,9 @@ if (process.env.NODE_ENV === 'development') {
 
 export default function configureStore() {
   const store = createStore(
-    persistedReducer,
+    rootReducer,
     debugWrapper(applyMiddleware(thunk, saveSettings))
   )
-  const persistor = persistStore(store)
 
   if (module.hot) {
     module.hot.accept('./rootReducer', () => {
@@ -30,5 +28,5 @@ export default function configureStore() {
     })
   }
 
-  return { store, persistor }
+  return store
 }

--- a/src/store/middleware.js
+++ b/src/store/middleware.js
@@ -3,10 +3,17 @@ import { Grid } from '../API'
 // eslint-disable-next-line
 export const saveSettings = store => next => async action => {
   if (action.type === 'CLIENT:SET_CONFIG') {
-    const settings = await Grid.Config.getItem('settings')
+    const settings = Grid.Config.getItem('settings')
     const newSettings = Object.assign({}, settings)
     newSettings[action.payload.clientName] = action.payload.config
-    await Grid.Config.setItem('settings', newSettings)
+    Grid.Config.setItem('settings', newSettings)
+  }
+
+  if (action.type === 'CLIENT:SELECT') {
+    const settings = Grid.Config.getItem('settings')
+    const newSettings = Object.assign({}, settings)
+    newSettings.selected = action.payload.clientName
+    Grid.Config.setItem('settings', newSettings)
   }
 
   return next(action)

--- a/src/store/middleware.js
+++ b/src/store/middleware.js
@@ -1,0 +1,12 @@
+import { Grid } from '../API'
+
+// eslint-disable-next-line
+export const saveSettings = store => next => async action => {
+  if (action.type === 'CLIENT:SET_CONFIG') {
+    const settings = await Grid.Config.getItem('settings')
+    settings[action.payload.clientName] = action.payload.config
+    await Grid.Config.setItem('settings', settings)
+  }
+
+  return next(action)
+}

--- a/src/store/middleware.js
+++ b/src/store/middleware.js
@@ -4,8 +4,9 @@ import { Grid } from '../API'
 export const saveSettings = store => next => async action => {
   if (action.type === 'CLIENT:SET_CONFIG') {
     const settings = await Grid.Config.getItem('settings')
-    settings[action.payload.clientName] = action.payload.config
-    await Grid.Config.setItem('settings', settings)
+    const newSettings = Object.assign({}, settings)
+    newSettings[action.payload.clientName] = action.payload.config
+    await Grid.Config.setItem('settings', newSettings)
   }
 
   return next(action)

--- a/src/store/rootReducer.js
+++ b/src/store/rootReducer.js
@@ -1,37 +1,8 @@
-import omit from 'lodash/omit'
 import { combineReducers } from 'redux'
-import { createTransform, persistReducer } from 'redux-persist'
-import storage from 'redux-persist/lib/storage'
-import client, { initialClientState } from './client/reducer'
-
-const pluginTransform = createTransform((inboundState, key) => {
-  if (key === 'client') {
-    const persistablePluginData = { selected: inboundState.selected }
-
-    const plugins = Object.keys(omit(inboundState, 'selected'))
-    plugins.forEach(plugin => {
-      persistablePluginData[plugin] = {
-        ...initialClientState,
-        config: inboundState[plugin].config
-      }
-    })
-
-    return persistablePluginData
-  }
-
-  return inboundState
-})
-
-const rootPersistConfig = {
-  key: 'root',
-  storage,
-  transforms: [
-    /* pluginTransform */
-  ]
-}
+import client from './client/reducer'
 
 const rootReducer = combineReducers({
   client
 })
 
-export default persistReducer(rootPersistConfig, rootReducer)
+export default rootReducer

--- a/src/store/rootReducer.js
+++ b/src/store/rootReducer.js
@@ -25,7 +25,9 @@ const pluginTransform = createTransform((inboundState, key) => {
 const rootPersistConfig = {
   key: 'root',
   storage,
-  transforms: [pluginTransform]
+  transforms: [
+    /* pluginTransform */
+  ]
 }
 
 const rootReducer = combineReducers({

--- a/src/test/settings.test.js
+++ b/src/test/settings.test.js
@@ -1,4 +1,4 @@
-import { getPluginSettingsConfig } from '../lib/utils'
+import { getDefaultSetting, getPluginSettingsConfig } from '../lib/utils'
 import { generateFlags } from '../lib/flags'
 
 describe('getPluginSettingsConfig', () => {
@@ -21,6 +21,25 @@ describe('getPluginSettingsConfig', () => {
     const settings = [{ id: 'one' }, { id: 'two' }]
     const client = { plugin: { config: { settings } } }
     expect(getPluginSettingsConfig(client)).toEqual(settings)
+  })
+})
+
+describe('getDefaultSetting', () => {
+  it('returns an empty string if no client', () => {
+    const client = undefined
+    expect(getDefaultSetting(client, 'network')).toEqual('')
+  })
+
+  it('returns an empty string if no id', () => {
+    const settings = [{ id: 'one', default: 'a' }, { id: 'two', default: 'b' }]
+    const client = { plugin: { config: { settings } } }
+    expect(getDefaultSetting(client, undefined)).toEqual('')
+  })
+
+  it('returns the default value', () => {
+    const settings = [{ id: 'one', default: 'a' }, { id: 'two', default: 'b' }]
+    const client = { plugin: { config: { settings } } }
+    expect(getDefaultSetting(client, 'two')).toEqual('b')
   })
 })
 

--- a/src/test/settings.test.js
+++ b/src/test/settings.test.js
@@ -1,4 +1,8 @@
-import { getDefaultSetting, getPluginSettingsConfig } from '../lib/utils'
+import {
+  getDefaultSetting,
+  getPluginSettingsConfig,
+  getSettingsIds
+} from '../lib/utils'
 import { generateFlags } from '../lib/flags'
 
 describe('getPluginSettingsConfig', () => {
@@ -40,6 +44,19 @@ describe('getDefaultSetting', () => {
     const settings = [{ id: 'one', default: 'a' }, { id: 'two', default: 'b' }]
     const client = { plugin: { config: { settings } } }
     expect(getDefaultSetting(client, 'two')).toEqual('b')
+  })
+})
+
+describe('getSettingsIds', () => {
+  it('returns an empty array if no client', () => {
+    const client = undefined
+    expect(getSettingsIds(client)).toEqual([])
+  })
+
+  it('returns an array of ids', () => {
+    const settings = [{ id: 'one', default: 'a' }, { id: 'two', default: 'b' }]
+    const client = { plugin: { config: { settings } } }
+    expect(getSettingsIds(client)).toEqual(['one', 'two'])
   })
 })
 


### PR DESCRIPTION
#### What does it do?
- ~Uses `redux-persist` to store user's configuration settings in localStorage.~
- Persists plugin settings via the config.json file.
- Introduces some logic to handle when to use rehydrated state.
#### Background
- Implementation done via redux middleware.
- To test, edit configs and add `"settings": {}` to the top-level keys, save, then restart the app. This change is reflected in this Grid PR: https://github.com/ethereum/grid/pull/311. If you already have a config.json file, however, you will need to make the change manually.
#### New dependencies? What are they used for?
~`redux-persist` (was already installed from previous work, though)~ jk
#### Does it close any issues?
Closes https://github.com/ethereum/grid/issues/23