### PR TITLE
feat: plugin list categories

### DIFF
--- a/src/components/Nodes/ServicesNav.js
+++ b/src/components/Nodes/ServicesNav.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
 import Drawer from '@material-ui/core/Drawer'
 import List from '@material-ui/core/List'
+import ListSubheader from '@material-ui/core/ListSubheader'
 import ServicesNavListItem from './ServicesNavListItem'
 
 const drawerWidth = 240
@@ -21,7 +22,12 @@ const styles = theme => ({
     padding: `${theme.spacing.unit * 9}px ${theme.spacing.unit * 3}px ${theme
       .spacing.unit * 3}px`
   },
-  toolbar: theme.mixins.toolbar
+  toolbar: theme.mixins.toolbar,
+  listSubheader: {
+    textTransform: 'uppercase',
+    fontSize: '80%',
+    height: '40px'
+  }
 })
 
 class ServicesTab extends Component {
@@ -73,24 +79,31 @@ class ServicesTab extends Component {
     )
   }
 
-  renderServiceListItems = () => {
-    const { clients } = this.props
-    const servicesSorted = clients.sort((a, b) => a.order - b.order)
-
-    // Build client list items
-    const clientsSorted = servicesSorted.filter(s => s.type === 'client')
-    const clientListItems = clientsSorted.map(c => this.buildListItem(c))
-
-    // Build other service list items
-    const otherServices = servicesSorted.filter(s => s.type !== 'client')
-    const serviceListItems = otherServices.map(s => this.buildListItem(s))
-
-    return (
-      <React.Fragment>
-        {clientListItems}
-        {serviceListItems}
-      </React.Fragment>
+  renderLists = () => {
+    const { clients, classes } = this.props
+    const types = [...new Set(clients.map(client => client.type))]
+    const buildList = type => (
+      <List
+        subheader={
+          <ListSubheader className={classes.listSubheader}>
+            {type}
+          </ListSubheader>
+        }
+      >
+        {this.renderClients(type)}
+      </List>
     )
+    const render = types.map(type => buildList(type))
+    return render
+  }
+
+  renderClients = type => {
+    const { clients } = this.props
+    const renderClients = clients
+      .filter(client => client.type === type)
+      .sort((a, b) => a.order - b.order)
+      .map(s => this.buildListItem(s))
+    return renderClients
   }
 
   render() {
@@ -104,7 +117,7 @@ class ServicesTab extends Component {
           classes={{ paper: classes.drawerPaper }}
         >
           <div className={classes.toolbar} />
-          <List>{this.renderServiceListItems()}</List>
+          {this.renderLists()}
         </Drawer>
         <main className={classes.content}>{children}</main>
       </React.Fragment>


### PR DESCRIPTION
#### What does it do?
Displays plugins sorted by their `type`

<img width="751" alt="Screen Shot 2019-06-26 at 4 58 16 PM" src="https://user-images.githubusercontent.com/22116/60222996-32d43480-9834-11e9-976c-8837639214db.png">

To test rendering of the list, you can add these plugins to grid `plugins.json`:
```
[
  {
    "name": "clef",
    "displayName": "Clef",
    "type": "signer",
    "author": {
      "name": "Ryan Ghods",
      "email": "ryan@ethereum.org",
      "address": "84741b205fe071833b97b081a87dc39fae078ff3"
    },
    "location": "https://github.com/ryanio/grid-clef-plugin"
  },
  {
    "name": "swarm",
    "displayName": "Swarm",
    "type": "storage",
    "author": {
      "name": "Philipp Langhans",
      "email": "philipp@ethereum.org",
      "address": "9fae5e6e2583216f23bdf94f74ceae26e209b31e"
    },
    "location": "https://github.com/PhilippLgh/grid-swarm-extension"
  }
]
```