### PR TITLE
fix: listSubheader material-ui warning

### DIFF
--- a/src/components/Nodes/ServicesNav.js
+++ b/src/components/Nodes/ServicesNav.js
@@ -93,7 +93,7 @@ class ServicesTab extends Component {
       <List
         key={type}
         subheader={
-          <ListSubheader key={type} classes={{ root: classes.listSubheader }}>
+          <ListSubheader classes={{ root: classes.listSubheader }}>
             {type}
           </ListSubheader>
         }

--- a/src/components/Nodes/ServicesNav.js
+++ b/src/components/Nodes/ServicesNav.js
@@ -62,7 +62,14 @@ class ServicesTab extends Component {
       selectedClientName
     } = this.props
 
-    const { content, drawer, drawerPaper, toolbar, ...restClasses } = classes
+    const {
+      content,
+      drawer,
+      drawerPaper,
+      toolbar,
+      listSubheader,
+      ...restClasses
+    } = classes
 
     return (
       <ServicesNavListItem
@@ -84,8 +91,9 @@ class ServicesTab extends Component {
     const types = [...new Set(clients.map(client => client.type))]
     const buildList = type => (
       <List
+        key={type}
         subheader={
-          <ListSubheader className={classes.listSubheader}>
+          <ListSubheader key={type} classes={{ root: classes.listSubheader }}>
             {type}
           </ListSubheader>
         }


### PR DESCRIPTION
#### What does it do?
Fixes small warning found in console due to passing of classes as props onto next component. This PR resolves the issue.

The warning found in console:
```index.js:1452 Warning: Material-UI: the key `listSubheader` provided to the classes property is not implemented in ServicesNavListItem.
You can only override one of the following: selected,serviceName,hoverableListItem,versionInfo.```