### PR TITLE
chore: update pluginError event name

### DIFF
--- a/src/store/client/clientService.js
+++ b/src/store/client/clientService.js
@@ -68,7 +68,7 @@ class ClientService {
     client.on('disconnect', () =>
       dispatch(onConnectionUpdate(client.name, 'DISCONNETED'))
     )
-    client.on('error', e => dispatch(clientError(client.name, e)))
+    client.on('pluginError', error => dispatch(clientError(client.name, error)))
   }
 
   removeListeners(client) {

--- a/src/store/client/clientService.js
+++ b/src/store/client/clientService.js
@@ -78,7 +78,7 @@ class ClientService {
     client.removeAllListeners('stopping')
     client.removeAllListeners('stopped')
     client.removeAllListeners('disconnect')
-    client.removeAllListeners('error')
+    client.removeAllListeners('pluginError')
   }
 
   onNewHeadsSubscriptionResult(client, result, dispatch) {


### PR DESCRIPTION
#### What does it do?
Updates listening from event name `error` to `pluginError` because when uncaught exceptions emit on `error` electron shows it in a blocking popup dialog to the user.

Event is updated in grid here: https://github.com/ethereum/grid/pull/321/commits/e5c38d22656876265f6e0e32fc56930c72787ed8

![image](https://user-images.githubusercontent.com/22116/60866362-ffeb5280-a1dc-11e9-8c59-b59a3b164ea9.png)
