### PR TITLE
fix: show 404 on app load fail

### DIFF
--- a/src/components/Webview/index.jsx
+++ b/src/components/Webview/index.jsx
@@ -19,6 +19,7 @@ class Webview extends React.Component {
     webview.addEventListener('will-navigate', this.handleWillNavigate)
     webview.addEventListener('ipc-message', this.handleIpcMessage)
     webview.addEventListener('dom-ready', this.handleDomReady)
+    webview.addEventListener('did-fail-load', this.handleDidFailLoad)
     if (url) {
       this.setState({
         currentUrl: url,
@@ -33,6 +34,7 @@ class Webview extends React.Component {
     webview.removeEventListener('will-navigate', this.handleNavigate)
     webview.removeEventListener('ipc-message', this.handleIpcMessage)
     webview.removeEventListener('dom-ready', this.handleDomReady)
+    webview.removeEventListener('did-fail-load', this.handleDidFailLoad)
   }
 
   handleDomReady = () => {
@@ -45,6 +47,14 @@ class Webview extends React.Component {
 
   handleIpcMessage = () => {
     console.log('Webview: handle ipc')
+  }
+
+  handleDidFailLoad = error => {
+    const { webview } = this
+    if (error.errorCode === -102) {
+      // ERR_CONNECTION_REFUSED
+      webview.loadURL(`${document.URL}/errors/404.html`)
+    }
   }
 
   handleNavigate = newUrl => {


### PR DESCRIPTION
#### What does it do?
Shows `404` page to user if an app fails to load. currently is just blank screen.

WIP: works in dev, needs more work to load `404.html` file path properly in prod