### PR TITLE
fix: pass clientName correctly to set custom flags

### DIFF
--- a/src/components/Nodes/ClientConfig/DynamicConfigForm/FlagPreview.jsx
+++ b/src/components/Nodes/ClientConfig/DynamicConfigForm/FlagPreview.jsx
@@ -25,7 +25,8 @@ class FlagPreview extends Component {
   handleChange = event => {
     const { dispatch, client } = this.props
     const flags = event.target.value.split(' ')
-    dispatch(setCustomFlags(client.name, flags))
+    const clientName = client[client.selected].name
+    dispatch(setCustomFlags(clientName, flags))
   }
 
   render() {


### PR DESCRIPTION
#### What does it do?
Fixes setting custom flags by passing `clientName` correctly