### PR TITLE
fix: changes from removeAllListeners to removeListeners + callback

### DIFF
--- a/src/store/client/clientService.js
+++ b/src/store/client/clientService.js
@@ -56,18 +56,23 @@ class ClientService {
   }
 
   createListeners(client, dispatch) {
-    client.on('newState', newState => {
+    this.newStateListener = newState => {
       dispatch(onConnectionUpdate(client.name, newState.toUpperCase()))
       if (newState === 'connected') {
         this.onConnect(client, dispatch)
       }
-    })
-    client.on('pluginError', error => dispatch(clientError(client.name, error)))
+    }
+
+    this.pluginErrorListener = error =>
+      dispatch(clientError(client.name, error))
+
+    client.on('newState', this.newStateListener)
+    client.on('pluginError', this.pluginErrorListener)
   }
 
   removeListeners(client) {
-    client.removeAllListeners('newState')
-    client.removeAllListeners('pluginError')
+    client.removeListener('newState', this.newStateListener)
+    client.removeListener('pluginError', this.pluginErrorListener)
   }
 
   onNewHeadsSubscriptionResult(client, result, dispatch) {


### PR DESCRIPTION
#### What does it do?

Removes only the listeners that grid-ui has started itself.

#### Any helpful background information?

#### New dependencies? What are they used for?

#### Relevant screenshots?

![Kapture 2019-07-24 at 14 58 52](https://user-images.githubusercontent.com/47108/61820961-2091ea00-ae24-11e9-9b57-f5f160b7d3bd.gif)

#### Does it close any issues?
Closes https://github.com/ethereum/grid/issues/368