### PR TITLE
feat: multiple errors

### DIFF
--- a/src/components/Nodes/ClientConfig/index.js
+++ b/src/components/Nodes/ClientConfig/index.js
@@ -39,7 +39,7 @@ class ClientConfig extends Component {
     isActiveClient: PropTypes.bool,
     handleReleaseSelect: PropTypes.func,
     handleClientConfigChanged: PropTypes.func,
-    clientError: PropTypes.string,
+    errors: PropTypes.array,
     selectedTab: PropTypes.number
   }
 
@@ -67,23 +67,29 @@ class ClientConfig extends Component {
     handleClientConfigChanged(key, value)
   }
 
-  dismissClientError = () => {
+  dismissError = index => {
     const { dispatch, client } = this.props
-    dispatch(clearError(client.name))
+    dispatch(clearError(client.name, index))
   }
 
   renderErrors() {
-    const { clientError } = this.props
-    if (clientError) {
-      return (
+    const { errors } = this.props
+    const renderErrors = []
+    errors.forEach((error, index) => {
+      const renderError = (
         <Notification
+          key={index}
           type="error"
-          message={clientError}
-          onDismiss={this.dismissClientError}
+          message={error}
+          onDismiss={() => {
+            this.dismissError(index)
+          }}
         />
       )
-    }
-    return null
+      renderErrors.push(renderError)
+    })
+
+    return renderErrors
   }
 
   render() {
@@ -167,7 +173,7 @@ function mapStateToProps(state) {
 
   return {
     clientStatus: state.client[selectedClient].active.status,
-    clientError: state.client[selectedClient].error,
+    errors: state.client[selectedClient].errors,
     isActiveClient: state.client[selectedClient].active.name !== 'STOPPED',
     selectedTab: state.client.selectedTab
   }

--- a/src/store/client/actions.js
+++ b/src/store/client/actions.js
@@ -115,14 +115,14 @@ export const updatePeerCountError = (clientName, message) => {
   }
 }
 
-export const clientError = (clientName, error) => {
-  return { type: 'CLIENT:ERROR', error, payload: { clientName } }
+export const addPluginError = (clientName, error) => {
+  return { type: 'CLIENT:ERROR:ADD', error, payload: { clientName } }
 }
 
-export const clearError = clientName => {
+export const clearError = (clientName, index) => {
   return {
     type: 'CLIENT:CLEAR_ERROR',
-    payload: { clientName }
+    payload: { clientName, index }
   }
 }
 

--- a/src/store/client/clientService.js
+++ b/src/store/client/clientService.js
@@ -2,7 +2,7 @@ import { BigNumber } from 'bignumber.js'
 import {
   newBlock,
   updateSyncing,
-  clientError,
+  addPluginError,
   onConnectionUpdate,
   updatePeerCount,
   updatePeerCountError
@@ -64,7 +64,7 @@ class ClientService {
     }
 
     this.pluginErrorListener = error =>
-      dispatch(clientError(client.name, error))
+      dispatch(addPluginError(client.name, error))
 
     client.on('newState', this.newStateListener)
     client.on('pluginError', this.pluginErrorListener)

--- a/src/store/client/reducer.js
+++ b/src/store/client/reducer.js
@@ -146,7 +146,11 @@ const client = (state = initialState, action) => {
           ...initialClientState,
           ...state[clientName],
           errors: [...state[clientName].errors, error],
-          active: { ...initialClientState.active, status: 'ERROR' }
+          active: {
+            ...initialClientState.active,
+            ...state[clientName].active,
+            status: 'ERROR'
+          }
         }
       }
     }

--- a/src/store/client/reducer.js
+++ b/src/store/client/reducer.js
@@ -25,7 +25,7 @@ export const initialClientState = {
   config: {},
   flags: [],
   displayName: '',
-  error: null,
+  errors: [],
   name: '',
   prefix: '',
   release: {
@@ -137,7 +137,7 @@ const client = (state = initialState, action) => {
         }
       }
     }
-    case 'CLIENT:ERROR': {
+    case 'CLIENT:ERROR:ADD': {
       const { payload, error } = action
       const { clientName } = payload
       return {
@@ -145,19 +145,22 @@ const client = (state = initialState, action) => {
         [clientName]: {
           ...initialClientState,
           ...state[clientName],
-          error,
+          errors: [...state[clientName].errors, error],
           active: { ...initialClientState.active, status: 'ERROR' }
         }
       }
     }
     case 'CLIENT:CLEAR_ERROR': {
-      const { clientName } = action.payload
+      const { clientName, index } = action.payload
+
       return {
         ...state,
         [clientName]: {
           ...initialClientState,
           ...state[clientName],
-          error: null
+          errors: state[clientName].errors.filter(
+            (n, nIndex) => nIndex !== index
+          )
         }
       }
     }

--- a/src/store/client/reducer.js
+++ b/src/store/client/reducer.js
@@ -145,12 +145,7 @@ const client = (state = initialState, action) => {
         [clientName]: {
           ...initialClientState,
           ...state[clientName],
-          errors: [...state[clientName].errors, error],
-          active: {
-            ...initialClientState.active,
-            ...state[clientName].active,
-            status: 'ERROR'
-          }
+          errors: [...state[clientName].errors, error]
         }
       }
     }

--- a/src/store/client/reducer.js
+++ b/src/store/client/reducer.js
@@ -107,7 +107,7 @@ const client = (state = initialState, action) => {
           ...initialClientState,
           ...state[clientName],
           active: { ...activeState, version },
-          error: null
+          errors: []
         }
       }
     }

--- a/src/store/client/reducer.test.js
+++ b/src/store/client/reducer.test.js
@@ -124,9 +124,9 @@ describe('the client reducer', () => {
     expect(reducer(initialState, action)).toEqual(expectedState)
   })
 
-  it('should handle CLIENT:ERROR', () => {
+  it('should handle CLIENT:ERROR:ADD', () => {
     const action = {
-      type: 'CLIENT:ERROR',
+      type: 'CLIENT:ERROR:ADD',
       error: 'Boom',
       payload: { clientName: 'geth' }
     }
@@ -134,7 +134,7 @@ describe('the client reducer', () => {
       ...initialState,
       geth: {
         ...initialClientState,
-        error: 'Boom',
+        errors: ['Boom'],
         active: { ...initialClientState.active, status: 'ERROR' }
       }
     }
@@ -145,11 +145,11 @@ describe('the client reducer', () => {
   it('should handle CLIENT:CLEAR_ERROR', () => {
     const action = {
       type: 'CLIENT:CLEAR_ERROR',
-      payload: { clientName: 'geth' }
+      payload: { clientName: 'geth', index: 0 }
     }
     const expectedState = {
       ...initialState,
-      geth: { ...initialClientState, error: null }
+      geth: { ...initialClientState, errors: [] }
     }
 
     expect(reducer(initialState, action)).toEqual(expectedState)

--- a/src/store/client/reducer.test.js
+++ b/src/store/client/reducer.test.js
@@ -134,8 +134,7 @@ describe('the client reducer', () => {
       ...initialState,
       geth: {
         ...initialClientState,
-        errors: ['Boom'],
-        active: { ...initialClientState.active, status: 'ERROR' }
+        errors: ['Boom']
       }
     }
 

--- a/src/store/client/reducer.test.js
+++ b/src/store/client/reducer.test.js
@@ -139,7 +139,9 @@ describe('the client reducer', () => {
       }
     }
 
-    expect(reducer(initialState, action)).toEqual(expectedState)
+    expect(
+      reducer({ ...initialState, geth: initialClientState }, action)
+    ).toEqual(expectedState)
   })
 
   it('should handle CLIENT:CLEAR_ERROR', () => {
@@ -152,7 +154,9 @@ describe('the client reducer', () => {
       geth: { ...initialClientState, errors: [] }
     }
 
-    expect(reducer(initialState, action)).toEqual(expectedState)
+    expect(
+      reducer({ ...initialState, geth: initialClientState }, action)
+    ).toEqual(expectedState)
   })
 
   it('should handle CLIENT:UPDATE_PEER_COUNT', () => {


### PR DESCRIPTION
#### What does it do?
Supports taking in multiple plugin errors to display in UI

![errors](https://user-images.githubusercontent.com/22116/61843708-0410a480-ae5a-11e9-8db5-65468703f09e.gif)

also, includes an update to not forcefully update redux state to `error`