### PR TITLE
fix: handle error object notifications

### DIFF
--- a/src/components/shared/Notification.js
+++ b/src/components/shared/Notification.js
@@ -44,7 +44,7 @@ class Notification extends Component {
   static propTypes = {
     classes: PropTypes.object.isRequired,
     type: PropTypes.string,
-    message: PropTypes.string,
+    message: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
     onDismiss: PropTypes.func.isRequired
   }
 
@@ -79,6 +79,9 @@ class Notification extends Component {
         break
     }
 
+    const displayMessage =
+      typeof message === 'object' ? message.message : message
+
     return (
       <Snackbar
         anchorOrigin={{
@@ -95,7 +98,7 @@ class Notification extends Component {
           message={
             <span>
               {icon}
-              {message}
+              {displayMessage}
             </span>
           }
           action={[

--- a/src/store/client/actions.js
+++ b/src/store/client/actions.js
@@ -51,7 +51,6 @@ export const initClient = client => {
     const flags =
       getPersistedFlags(client.name) || getGeneratedFlags(client, config)
     const release = client.plugin.getSelectedRelease()
-    console.log('RELEASE', release)
 
     dispatch({
       type: 'CLIENT:INIT',


### PR DESCRIPTION
#### What does it do?
Handles error message objects in `Notification`s
#### Any helpful background information?
Reproduce by starting parity, stopping, starting again.