### PR TITLE
fix: plugin name refactor v3

### DIFF
--- a/src/components/Plugins/index.js
+++ b/src/components/Plugins/index.js
@@ -4,13 +4,13 @@ import PropTypes from 'prop-types'
 import ClientConfig from './ClientConfig'
 import ServicesNav from './ServicesNav'
 import {
-  initClient,
-  selectClient,
+  initPlugin,
+  selectPlugin,
   setConfig,
-  toggleClient
+  togglePlugin
 } from '../../store/plugin/actions'
 import {
-  getPersistedClientSelection,
+  getPersistedPluginSelection,
   getPersistedTabSelection
 } from '../../lib/utils'
 
@@ -20,92 +20,92 @@ const { PluginHost } = Grid
 
 class PluginsTab extends Component {
   static propTypes = {
-    clientState: PropTypes.object.isRequired,
+    pluginState: PropTypes.object.isRequired,
     dispatch: PropTypes.func.isRequired
   }
 
   state = {
-    clients: [],
-    selectedClient: undefined
+    plugins: [],
+    selectedPlugin: undefined
   }
 
   componentDidMount() {
     if (!PluginHost) return
     const plugins = PluginHost.getAllPlugins()
-    this.initClients(plugins)
+    this.initPlugins(plugins)
   }
 
-  initClients = clients => {
-    const { clientState, dispatch } = this.props
+  initPlugins = plugins => {
+    const { pluginState, dispatch } = this.props
 
-    // Sync clients with Redux
-    clients.map(client => dispatch(initClient(client)))
+    // Sync plugins with Redux
+    plugins.map(plugin => dispatch(initPlugin(plugin)))
 
-    // Set the selected client from config.json or a fallback method
-    const selectedClient =
-      clients.find(client => client.name === getPersistedClientSelection()) ||
-      clients.find(client => client.name === clientState.selected) ||
-      clients.find(client => client.order === 1) ||
-      clients[0]
+    // Set the selected plugin from config.json or a fallback method
+    const selectedPlugin =
+      plugins.find(plugin => plugin.name === getPersistedPluginSelection()) ||
+      plugins.find(plugin => plugin.name === pluginState.selected) ||
+      plugins.find(plugin => plugin.order === 1) ||
+      plugins[0]
     const selectedTab = getPersistedTabSelection()
-    this.handleSelectClient(selectedClient, selectedTab)
+    this.handleSelectPlugin(selectedPlugin, selectedTab)
 
     // TODO: two sources of truth - local and redux state
-    this.setState({ clients })
+    this.setState({ plugins })
   }
 
-  isDisabled = client => {
-    const { selectedRelease } = client
+  isDisabled = plugin => {
+    const { selectedRelease } = plugin
     return !selectedRelease
   }
 
-  handleSelectClient = (client, tab) => {
+  handleSelectPlugin = (plugin, tab) => {
     const { dispatch } = this.props
 
-    this.setState({ selectedClient: client }, () => {
-      dispatch(selectClient(client.name, tab))
+    this.setState({ selectedPlugin: plugin }, () => {
+      dispatch(selectPlugin(plugin.name, tab))
     })
   }
 
-  handleClientConfigChanged = (key, value) => {
-    const { clientState, dispatch } = this.props
-    const { clients } = this.state
+  handlePluginConfigChanged = (key, value) => {
+    const { pluginState, dispatch } = this.props
+    const { plugins } = this.state
 
-    const client = clients.filter(c => c.name === clientState.selected)[0]
+    const plugin = plugins.filter(c => c.name === pluginState.selected)[0]
 
-    const { config } = clientState[clientState.selected]
+    const { config } = pluginState[pluginState.selected]
     const newConfig = { ...config }
     newConfig[key] = value
 
-    dispatch(setConfig(client, newConfig))
+    dispatch(setConfig(plugin, newConfig))
   }
 
   handleReleaseSelect = release => {
-    const { selectedClient } = this.state
-    selectedClient.selectedRelease = release
-    this.setState({ selectedClient, selectedRelease: release })
+    const { selectedPlugin } = this.state
+    selectedPlugin.selectedRelease = release
+    this.setState({ selectedPlugin, selectedRelease: release })
   }
 
-  handleToggle = client => {
-    const { clientState, dispatch } = this.props
-    // TODO: refactor to only require clientName to toggle?
-    dispatch(toggleClient(client, clientState[client.name].release))
+  handleToggle = plugin => {
+    const { pluginState, dispatch } = this.props
+    // TODO: refactor to only require pluginName to toggle?
+    dispatch(togglePlugin(plugin, pluginState[plugin.name].release))
   }
 
   render() {
-    const { clients, selectedClient, selectedRelease } = this.state
+    const { plugins, selectedPlugin, selectedRelease } = this.state
 
     return (
       <ServicesNav
         handleToggle={this.handleToggle}
-        handleSelectClient={this.handleSelectClient}
-        clients={clients}
+        handleSelectClient={this.handleSelectPlugin}
+        clients={plugins}
       >
-        {selectedClient && (
+        {selectedPlugin && (
           <ClientConfig
-            client={selectedClient}
+            client={selectedPlugin}
             selectedRelease={selectedRelease}
-            handleClientConfigChanged={this.handleClientConfigChanged}
+            handlePluginConfigChanged={this.handlePluginConfigChanged}
             handleReleaseSelect={this.handleReleaseSelect}
           />
         )}
@@ -116,7 +116,7 @@ class PluginsTab extends Component {
 
 function mapStateToProps(state) {
   return {
-    clientState: state.plugin
+    pluginState: state.plugin
   }
 }
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -61,7 +61,7 @@ export const getSettingsIds = client => {
   }
 }
 
-export const getPersistedClientSettings = clientName => {
+export const getPersistedPluginSettings = clientName => {
   try {
     const settings = Grid.Config.getItem('settings')
     return settings[clientName] || {}
@@ -79,7 +79,7 @@ export const getPersistedFlags = clientName => {
   }
 }
 
-export const getPersistedClientSelection = () => {
+export const getPersistedPluginSelection = () => {
   try {
     const settings = Grid.Config.getItem('settings')
     return settings.selected || ''

--- a/src/store/plugin/reducer.js
+++ b/src/store/plugin/reducer.js
@@ -1,12 +1,12 @@
 export const initialState = {
   selected: 'geth',
   selectedTab: 0
-  // Clients dynamically populate within this object, e.g.
+  // Plugins dynamically populate within this object, e.g.
   // geth: { config: {}, release: {}, ... },
   // parity: { config: {}, release: {}, ... },
 }
 
-export const initialClientState = {
+export const initialPluginState = {
   active: {
     blockNumber: null,
     peerCount: 0,
@@ -47,8 +47,8 @@ const plugin = (state = initialState, action) => {
   switch (action.type) {
     case 'PLUGIN:INIT': {
       const {
-        clientName,
-        clientData,
+        pluginName,
+        pluginData,
         config,
         type,
         flags,
@@ -56,157 +56,157 @@ const plugin = (state = initialState, action) => {
       } = action.payload
       const newState = {
         ...state,
-        [clientName]: {
-          ...initialClientState,
-          ...clientData,
+        [pluginName]: {
+          ...initialPluginState,
+          ...pluginData,
           config,
           type,
           flags
         }
       }
       if (release) {
-        newState[clientName].release = release
+        newState[pluginName].release = release
       }
       return newState
     }
     case 'PLUGIN:SELECT': {
-      const { clientName, tab } = action.payload
-      return { ...state, selected: clientName, selectedTab: tab }
+      const { pluginName, tab } = action.payload
+      return { ...state, selected: pluginName, selectedTab: tab }
     }
     case 'PLUGIN:SELECT_TAB': {
       const { tab } = action.payload
       return { ...state, selectedTab: tab }
     }
     case 'PLUGIN:SET_RELEASE': {
-      const { clientName, release } = action.payload
+      const { pluginName, release } = action.payload
       return {
         ...state,
-        [clientName]: { ...initialClientState, ...state[clientName], release }
+        [pluginName]: { ...initialPluginState, ...state[pluginName], release }
       }
     }
     case 'PLUGIN:SET_CONFIG': {
-      const { clientName, config } = action.payload
+      const { pluginName, config } = action.payload
       return {
         ...state,
-        [clientName]: {
-          ...initialClientState,
-          ...state[clientName],
+        [pluginName]: {
+          ...initialPluginState,
+          ...state[pluginName],
           config
         }
       }
     }
     case 'PLUGIN:SET_FLAGS': {
-      const { clientName, flags } = action.payload
+      const { pluginName, flags } = action.payload
       return {
         ...state,
-        [clientName]: {
-          ...initialClientState,
-          ...state[clientName],
+        [pluginName]: {
+          ...initialPluginState,
+          ...state[pluginName],
           flags
         }
       }
     }
     case 'PLUGIN:START': {
-      const { clientName, version } = action.payload
-      const activeState = state[clientName]
-        ? state[clientName].active
-        : initialClientState.active
+      const { pluginName, version } = action.payload
+      const activeState = state[pluginName]
+        ? state[pluginName].active
+        : initialPluginState.active
 
       return {
         ...state,
-        [clientName]: {
-          ...initialClientState,
-          ...state[clientName],
+        [pluginName]: {
+          ...initialPluginState,
+          ...state[pluginName],
           active: { ...activeState, version },
           errors: []
         }
       }
     }
     case 'PLUGIN:STATUS_UPDATE': {
-      const { clientName, status } = action.payload
-      const activeState = state[clientName]
-        ? state[clientName].active
-        : initialClientState.active
+      const { pluginName, status } = action.payload
+      const activeState = state[pluginName]
+        ? state[pluginName].active
+        : initialPluginState.active
 
       return {
         ...state,
-        [clientName]: {
-          ...initialClientState,
-          ...state[clientName],
+        [pluginName]: {
+          ...initialPluginState,
+          ...state[pluginName],
           active: { ...activeState, status }
         }
       }
     }
     case 'PLUGIN:STOP': {
-      const { clientName } = action.payload
+      const { pluginName } = action.payload
       return {
         ...state,
-        [clientName]: {
-          ...initialClientState,
-          ...state[clientName],
-          active: { ...initialClientState.active }
+        [pluginName]: {
+          ...initialPluginState,
+          ...state[pluginName],
+          active: { ...initialPluginState.active }
         }
       }
     }
     case 'PLUGIN:ERROR:ADD': {
       const { payload, error } = action
-      const { clientName } = payload
+      const { pluginName } = payload
       return {
         ...state,
-        [clientName]: {
-          ...initialClientState,
-          ...state[clientName],
-          errors: [...state[clientName].errors, error]
+        [pluginName]: {
+          ...initialPluginState,
+          ...state[pluginName],
+          errors: [...state[pluginName].errors, error]
         }
       }
     }
     case 'PLUGIN:CLEAR_ERROR': {
-      const { clientName, index } = action.payload
+      const { pluginName, index } = action.payload
 
       return {
         ...state,
-        [clientName]: {
-          ...initialClientState,
-          ...state[clientName],
-          errors: state[clientName].errors.filter(
+        [pluginName]: {
+          ...initialPluginState,
+          ...state[pluginName],
+          errors: state[pluginName].errors.filter(
             (n, nIndex) => nIndex !== index
           )
         }
       }
     }
     case 'PLUGIN:UPDATE_NEW_BLOCK': {
-      const { clientName, blockNumber, timestamp } = action.payload
-      const activeState = state[clientName]
-        ? state[clientName].active
-        : initialClientState.active
+      const { pluginName, blockNumber, timestamp } = action.payload
+      const activeState = state[pluginName]
+        ? state[pluginName].active
+        : initialPluginState.active
 
       return {
         ...state,
-        [clientName]: {
-          ...initialClientState,
-          ...state[clientName],
+        [pluginName]: {
+          ...initialPluginState,
+          ...state[pluginName],
           active: { ...activeState, blockNumber, timestamp }
         }
       }
     }
     case 'PLUGIN:UPDATE_SYNCING': {
       const {
-        clientName,
+        pluginName,
         startingBlock,
         currentBlock,
         highestBlock,
         knownStates,
         pulledStates
       } = action.payload
-      const activeState = state[clientName]
-        ? state[clientName].active
-        : initialClientState.active
+      const activeState = state[pluginName]
+        ? state[pluginName].active
+        : initialPluginState.active
 
       return {
         ...state,
-        [clientName]: {
-          ...initialClientState,
-          ...state[clientName],
+        [pluginName]: {
+          ...initialPluginState,
+          ...state[pluginName],
           active: {
             ...activeState,
             sync: {
@@ -222,16 +222,16 @@ const plugin = (state = initialState, action) => {
       }
     }
     case 'PLUGIN:UPDATE_PEER_COUNT': {
-      const { clientName, peerCount } = action.payload
-      const activeState = state[clientName]
-        ? state[clientName].active
-        : initialClientState.active
+      const { pluginName, peerCount } = action.payload
+      const activeState = state[pluginName]
+        ? state[pluginName].active
+        : initialPluginState.active
 
       return {
         ...state,
-        [clientName]: {
-          ...initialClientState,
-          ...state[clientName],
+        [pluginName]: {
+          ...initialPluginState,
+          ...state[pluginName],
           active: { ...activeState, peerCount }
         }
       }

--- a/src/store/plugin/reducer.test.js
+++ b/src/store/plugin/reducer.test.js
@@ -1,12 +1,12 @@
-import reducer, { initialState, initialClientState } from './reducer'
+import reducer, { initialState, initialPluginState } from './reducer'
 
-describe('the client reducer', () => {
+describe('the plugin reducer', () => {
   it('should handle PLUGIN:INIT', () => {
     const action = {
       type: 'PLUGIN:INIT',
       payload: {
-        clientName: 'parity',
-        clientData: {
+        pluginName: 'parity',
+        pluginData: {
           name: 'parity',
           displayName: 'Parity',
           config: { default: { sync: 'warp' } }
@@ -19,7 +19,7 @@ describe('the client reducer', () => {
     const expectedState = {
       ...initialState,
       parity: {
-        ...initialClientState,
+        ...initialPluginState,
         name: 'parity',
         displayName: 'Parity',
         config: { sync: 'warp' },
@@ -34,7 +34,7 @@ describe('the client reducer', () => {
   it('should handle PLUGIN:SELECT', () => {
     const action = {
       type: 'PLUGIN:SELECT',
-      payload: { clientName: 'parity', tab: 0 }
+      payload: { pluginName: 'parity', tab: 0 }
     }
     const expectedState = { ...initialState, selected: 'parity' }
 
@@ -63,11 +63,11 @@ describe('the client reducer', () => {
     }
     const action = {
       type: 'PLUGIN:SET_CONFIG',
-      payload: { clientName: 'geth', config }
+      payload: { pluginName: 'geth', config }
     }
     const expectedState = {
       ...initialState,
-      geth: { ...initialClientState, config }
+      geth: { ...initialPluginState, config }
     }
 
     expect(reducer(initialState, action)).toEqual(expectedState)
@@ -77,15 +77,15 @@ describe('the client reducer', () => {
     const action = {
       type: 'PLUGIN:START',
       payload: {
-        clientName: 'geth',
+        pluginName: 'geth',
         version: '1.X.X'
       }
     }
     const expectedState = {
       ...initialState,
       geth: {
-        ...initialClientState,
-        active: { ...initialClientState.active, version: '1.X.X' }
+        ...initialPluginState,
+        active: { ...initialPluginState.active, version: '1.X.X' }
       }
     }
 
@@ -96,15 +96,15 @@ describe('the client reducer', () => {
     const action = {
       type: 'PLUGIN:STATUS_UPDATE',
       payload: {
-        clientName: 'geth',
+        pluginName: 'geth',
         status: 'STARTED'
       }
     }
     const expectedState = {
       ...initialState,
       geth: {
-        ...initialClientState,
-        active: { ...initialClientState.active, status: 'STARTED' }
+        ...initialPluginState,
+        active: { ...initialPluginState.active, status: 'STARTED' }
       }
     }
 
@@ -114,11 +114,11 @@ describe('the client reducer', () => {
   it('should handle PLUGIN:STOP', () => {
     const action = {
       type: 'PLUGIN:STOP',
-      payload: { clientName: 'geth' }
+      payload: { pluginName: 'geth' }
     }
     const expectedState = {
       ...initialState,
-      geth: { ...initialClientState }
+      geth: { ...initialPluginState }
     }
 
     expect(reducer(initialState, action)).toEqual(expectedState)
@@ -128,46 +128,46 @@ describe('the client reducer', () => {
     const action = {
       type: 'PLUGIN:ERROR:ADD',
       error: 'Boom',
-      payload: { clientName: 'geth' }
+      payload: { pluginName: 'geth' }
     }
     const expectedState = {
       ...initialState,
       geth: {
-        ...initialClientState,
+        ...initialPluginState,
         errors: ['Boom']
       }
     }
 
     expect(
-      reducer({ ...initialState, geth: initialClientState }, action)
+      reducer({ ...initialState, geth: initialPluginState }, action)
     ).toEqual(expectedState)
   })
 
   it('should handle PLUGIN:CLEAR_ERROR', () => {
     const action = {
       type: 'PLUGIN:CLEAR_ERROR',
-      payload: { clientName: 'geth', index: 0 }
+      payload: { pluginName: 'geth', index: 0 }
     }
     const expectedState = {
       ...initialState,
-      geth: { ...initialClientState, errors: [] }
+      geth: { ...initialPluginState, errors: [] }
     }
 
     expect(
-      reducer({ ...initialState, geth: initialClientState }, action)
+      reducer({ ...initialState, geth: initialPluginState }, action)
     ).toEqual(expectedState)
   })
 
   it('should handle PLUGIN:UPDATE_PEER_COUNT', () => {
     const action = {
       type: 'PLUGIN:UPDATE_PEER_COUNT',
-      payload: { clientName: 'geth', peerCount: '3' }
+      payload: { pluginName: 'geth', peerCount: '3' }
     }
     const expectedState = {
       ...initialState,
       geth: {
-        ...initialClientState,
-        active: { ...initialClientState.active, peerCount: '3' }
+        ...initialPluginState,
+        active: { ...initialPluginState.active, peerCount: '3' }
       }
     }
 
@@ -187,11 +187,11 @@ describe('the client reducer', () => {
     }
     const action = {
       type: 'PLUGIN:SET_RELEASE',
-      payload: { clientName: 'geth', release }
+      payload: { pluginName: 'geth', release }
     }
     const expectedState = {
       ...initialState,
-      geth: { ...initialClientState, release }
+      geth: { ...initialPluginState, release }
     }
 
     expect(reducer(initialState, action)).toEqual(expectedState)
@@ -202,13 +202,13 @@ describe('the client reducer', () => {
     const timestamp = '321321321'
     const action = {
       type: 'PLUGIN:UPDATE_NEW_BLOCK',
-      payload: { clientName: 'geth', blockNumber, timestamp }
+      payload: { pluginName: 'geth', blockNumber, timestamp }
     }
     const expectedState = {
       ...initialState,
       geth: {
-        ...initialClientState,
-        active: { ...initialClientState.active, blockNumber, timestamp }
+        ...initialPluginState,
+        active: { ...initialPluginState.active, blockNumber, timestamp }
       }
     }
 
@@ -225,13 +225,13 @@ describe('the client reducer', () => {
     }
     const action = {
       type: 'PLUGIN:UPDATE_SYNCING',
-      payload: { clientName: 'geth', ...sync }
+      payload: { pluginName: 'geth', ...sync }
     }
     const expectedState = {
       ...initialState,
       geth: {
-        ...initialClientState,
-        active: { ...initialClientState.active, sync }
+        ...initialPluginState,
+        active: { ...initialPluginState.active, sync }
       }
     }
 


### PR DESCRIPTION
#### What does it do?
`client` -> `plugin` naming updates for all Redux files, utils, and the Plugins index file. 
#### Any helpful background information?
Only several hundred more `client` references remaining in the app 😅 
#### Does it close any issues?
Partially addresses https://github.com/ethereum/grid/issues/395 and https://github.com/ethereum/grid/issues/394