### PR TITLE
chore: refactor client PluginService funcs into ClientService

### DIFF
--- a/src/store/plugin/clientService.js
+++ b/src/store/plugin/clientService.js
@@ -29,6 +29,10 @@ class ClientService {
     }
   }
 
+  clearPeerCountInterval() {
+    clearInterval(this.peerCountInterval)
+  }
+
   onNewHeadsSubscriptionResult(plugin, result, dispatch) {
     const { result: subscriptionResult } = result
     if (!subscriptionResult) return

--- a/src/store/plugin/clientService.js
+++ b/src/store/plugin/clientService.js
@@ -1,0 +1,152 @@
+import { BigNumber } from 'bignumber.js'
+import {
+  newBlock,
+  updateSyncing,
+  updatePeerCount,
+  updatePeerCountError
+} from './actions'
+
+// Utils
+const isHex = str => typeof str === 'string' && str.startsWith('0x')
+const hexToNumberString = str => new BigNumber(str).toString(10)
+const toNumberString = str => (isHex(str) ? hexToNumberString(str) : str)
+
+class ClientService {
+  watchForPeers(plugin, dispatch) {
+    this.peerCountInterval = setInterval(
+      () => this.updatePeerCount(plugin, dispatch),
+      3000
+    )
+  }
+
+  async updatePeerCount(plugin, dispatch) {
+    const hexPeerCount = await plugin.rpc('net_peerCount')
+    if (hexPeerCount.message) {
+      dispatch(updatePeerCountError(plugin.name, hexPeerCount.message))
+    } else {
+      const peerCount = toNumberString(hexPeerCount)
+      dispatch(updatePeerCount(plugin.name, peerCount))
+    }
+  }
+
+  onNewHeadsSubscriptionResult(plugin, result, dispatch) {
+    const { result: subscriptionResult } = result
+    if (!subscriptionResult) return
+
+    const {
+      number: hexBlockNumber,
+      timestamp: hexTimestamp
+    } = subscriptionResult
+    const blockNumber = Number(toNumberString(hexBlockNumber))
+    const timestamp = Number(toNumberString(hexTimestamp))
+    dispatch(newBlock(plugin.name, blockNumber, timestamp))
+  }
+
+  onSyncingSubscriptionResult(plugin, result, dispatch) {
+    if (result === false) {
+      // Stopped syncing, begin newHeads subscription
+      this.startNewHeadsSubscription(plugin, dispatch)
+      // Unsubscribe from syncing subscription
+      this.unsubscribeSyncingSubscription(plugin)
+      return
+    }
+
+    // waiting for syncing data
+    if (result === true) return
+
+    const { status } = result
+    if (!status) return
+
+    const {
+      StartingBlock: startingBlock,
+      CurrentBlock: currentBlock,
+      HighestBlock: highestBlock,
+      KnownStates: knownStates,
+      PulledStates: pulledStates
+    } = status
+
+    dispatch(
+      updateSyncing(plugin.name, {
+        startingBlock,
+        currentBlock,
+        highestBlock,
+        knownStates,
+        pulledStates
+      })
+    )
+  }
+
+  unsubscribeNewHeadsSubscription(plugin) {
+    if (!this.newHeadsSubscriptionId) return
+    plugin.rpc('eth_unsubscribe', [this.newHeadsSubscriptionId])
+    plugin.removeListener(
+      this.newHeadsSubscriptionId,
+      this.onNewHeadsSubscriptionResult
+    )
+    this.newHeadsSubscriptionId = null
+  }
+
+  unsubscribeSyncingSubscription(plugin) {
+    if (!this.syncingSubscriptionId) return
+    plugin.rpc('eth_unsubscribe', [this.syncingSubscriptionId])
+    plugin.removeListener(
+      this.syncingSubscriptionId,
+      this.onSyncingSubscriptionResult
+    )
+    this.syncingSubscriptionId = null
+  }
+
+  startBlockSubscriptions(plugin, dispatch) {
+    const startSubscriptions = async () => {
+      const result = await plugin.rpc('eth_syncing')
+      if (result === false) {
+        // Not syncing, start newHeads subscription
+        this.startNewHeadsSubscription(plugin, dispatch)
+      } else {
+        // Subscribe to syncing
+        this.startSyncingSubscription(plugin, dispatch)
+      }
+    }
+
+    const setLastBlock = () => {
+      plugin.rpc('eth_getBlockByNumber', ['latest', false]).then(block => {
+        const { number: hexBlockNumber, timestamp: hexTimestamp } = block
+        const blockNumber = Number(toNumberString(hexBlockNumber))
+        const timestamp = Number(toNumberString(hexTimestamp))
+        dispatch(newBlock(plugin.name, blockNumber, timestamp))
+      })
+    }
+
+    setTimeout(() => {
+      setLastBlock()
+      startSubscriptions()
+    }, 2000)
+  }
+
+  async startNewHeadsSubscription(plugin, dispatch) {
+    plugin.rpc('eth_subscribe', ['newHeads']).then(subscriptionId => {
+      this.newHeadsSubscriptionId = subscriptionId
+      plugin.on('notification', result => {
+        const { subscription } = result
+        if (subscription === this.newHeadsSubscriptionId) {
+          this.onNewHeadsSubscriptionResult(plugin, result, dispatch)
+        }
+      })
+    })
+  }
+
+  async startSyncingSubscription(plugin, dispatch) {
+    console.log('∆∆∆ startSyncingSubscription')
+    const subscriptionId = await plugin.rpc('eth_subscribe', ['syncing'])
+    this.syncingSubscriptionId = subscriptionId
+    plugin.on('notification', result => {
+      const { subscription } = result
+      if (subscription === this.newHeadsSubscriptionId) {
+        console.log('∆∆∆ subscriptionId syncing', subscriptionId, result)
+        this.onSyncingSubscriptionResult(plugin, result, dispatch)
+      }
+    })
+  }
+}
+
+export default new ClientService()

--- a/src/store/plugin/pluginService.js
+++ b/src/store/plugin/pluginService.js
@@ -1,204 +1,58 @@
-import { BigNumber } from 'bignumber.js'
-import {
-  newBlock,
-  updateSyncing,
-  addPluginError,
-  onConnectionUpdate,
-  updatePeerCount,
-  updatePeerCountError
-} from './actions'
+import ClientService from './clientService'
+import { addPluginError, onConnectionUpdate } from './actions'
 
-// Utils
-const isHex = str => typeof str === 'string' && str.startsWith('0x')
-const hexToNumberString = str => new BigNumber(str).toString(10)
-const toNumberString = str => (isHex(str) ? hexToNumberString(str) : str)
-
-class ClientService {
-  start(client, release, flags, config, dispatch) {
-    client.start(release, flags, config)
-    if (client.type === 'client') this.watchForPeers(client, dispatch)
+class PluginService {
+  start(plugin, release, flags, config, dispatch) {
+    plugin.start(release, flags, config)
+    if (plugin.type === 'client') ClientService.watchForPeers(plugin, dispatch)
   }
 
-  resume(client, dispatch) {
-    if (client.type === 'client') this.watchForPeers(client, dispatch)
-    dispatch(onConnectionUpdate(client.name, client.state))
+  resume(plugin, dispatch) {
+    if (plugin.type === 'client') ClientService.watchForPeers(plugin, dispatch)
+    dispatch(onConnectionUpdate(plugin.name, plugin.state))
 
     // `resume` is called for 'STARTED', 'STARTING', and 'CONNECTED' states.
     // If plugin starts as 'CONNECTED', manually trigger `onConnect`.
-    if (client.state === 'CONNECTED') {
-      this.onConnect(client, dispatch)
+    if (plugin.state === 'CONNECTED') {
+      this.onConnect(plugin, dispatch)
     }
   }
 
-  stop(client) {
-    client.stop()
-    clearInterval(this.peerCountInterval)
-    this.unsubscribeSyncingSubscription(client)
-    this.unsubscribeNewHeadsSubscription(client)
-    this.removeListeners(client)
+  stop(plugin) {
+    plugin.stop()
+    this.removeListeners(plugin)
   }
 
-  watchForPeers(client, dispatch) {
-    this.peerCountInterval = setInterval(
-      () => this.updatePeerCount(client, dispatch),
-      3000
-    )
-  }
-
-  async updatePeerCount(client, dispatch) {
-    const hexPeerCount = await client.rpc('net_peerCount')
-    if (hexPeerCount.message) {
-      dispatch(updatePeerCountError(client.name, hexPeerCount.message))
-    } else {
-      const peerCount = toNumberString(hexPeerCount)
-      dispatch(updatePeerCount(client.name, peerCount))
+  onConnect(plugin, dispatch) {
+    if (plugin.type === 'client') {
+      ClientService.startBlockSubscriptions(plugin, dispatch)
     }
   }
 
-  createListeners(client, dispatch) {
+  createListeners(plugin, dispatch) {
     this.newStateListener = newState => {
-      dispatch(onConnectionUpdate(client.name, newState.toUpperCase()))
+      dispatch(onConnectionUpdate(plugin.name, newState.toUpperCase()))
       if (newState === 'connected') {
-        this.onConnect(client, dispatch)
+        this.onConnect(plugin, dispatch)
       }
     }
 
     this.pluginErrorListener = error =>
-      dispatch(addPluginError(client.name, error))
+      dispatch(addPluginError(plugin.name, error))
 
-    client.on('newState', this.newStateListener)
-    client.on('pluginError', this.pluginErrorListener)
+    plugin.on('newState', this.newStateListener)
+    plugin.on('pluginError', this.pluginErrorListener)
   }
 
-  removeListeners(client) {
-    client.removeListener('newState', this.newStateListener)
-    client.removeListener('pluginError', this.pluginErrorListener)
-  }
-
-  onNewHeadsSubscriptionResult(client, result, dispatch) {
-    const { result: subscriptionResult } = result
-    if (!subscriptionResult) return
-
-    const {
-      number: hexBlockNumber,
-      timestamp: hexTimestamp
-    } = subscriptionResult
-    const blockNumber = Number(toNumberString(hexBlockNumber))
-    const timestamp = Number(toNumberString(hexTimestamp))
-    dispatch(newBlock(client.name, blockNumber, timestamp))
-  }
-
-  onSyncingSubscriptionResult(client, result, dispatch) {
-    if (result === false) {
-      // Stopped syncing, begin newHeads subscription
-      this.startNewHeadsSubscription(client, dispatch)
-      // Unsubscribe from syncing subscription
-      this.unsubscribeSyncingSubscription(client)
-      return
+  removeListeners(plugin) {
+    plugin.removeListener('newState', this.newStateListener)
+    plugin.removeListener('pluginError', this.pluginErrorListener)
+    if (plugin.type === 'client') {
+      clearInterval(this.peerCountInterval)
+      ClientService.unsubscribeSyncingSubscription(plugin)
+      ClientService.unsubscribeNewHeadsSubscription(plugin)
     }
-
-    // waiting for syncing data
-    if (result === true) return
-
-    const { status } = result
-    if (!status) return
-
-    const {
-      StartingBlock: startingBlock,
-      CurrentBlock: currentBlock,
-      HighestBlock: highestBlock,
-      KnownStates: knownStates,
-      PulledStates: pulledStates
-    } = status
-
-    dispatch(
-      updateSyncing(client.name, {
-        startingBlock,
-        currentBlock,
-        highestBlock,
-        knownStates,
-        pulledStates
-      })
-    )
-  }
-
-  unsubscribeNewHeadsSubscription(client) {
-    if (!this.newHeadsSubscriptionId) return
-    client.rpc('eth_unsubscribe', [this.newHeadsSubscriptionId])
-    client.removeListener(
-      this.newHeadsSubscriptionId,
-      this.onNewHeadsSubscriptionResult
-    )
-    this.newHeadsSubscriptionId = null
-  }
-
-  unsubscribeSyncingSubscription(client) {
-    if (!this.syncingSubscriptionId) return
-    client.rpc('eth_unsubscribe', [this.syncingSubscriptionId])
-    client.removeListener(
-      this.syncingSubscriptionId,
-      this.onSyncingSubscriptionResult
-    )
-    this.syncingSubscriptionId = null
-  }
-
-  startBlockSubscriptions(client, dispatch) {
-    const startSubscriptions = async () => {
-      const result = await client.rpc('eth_syncing')
-      if (result === false) {
-        // Not syncing, start newHeads subscription
-        this.startNewHeadsSubscription(client, dispatch)
-      } else {
-        // Subscribe to syncing
-        this.startSyncingSubscription(client, dispatch)
-      }
-    }
-
-    const setLastBlock = () => {
-      client.rpc('eth_getBlockByNumber', ['latest', false]).then(block => {
-        const { number: hexBlockNumber, timestamp: hexTimestamp } = block
-        const blockNumber = Number(toNumberString(hexBlockNumber))
-        const timestamp = Number(toNumberString(hexTimestamp))
-        dispatch(newBlock(client.name, blockNumber, timestamp))
-      })
-    }
-
-    setTimeout(() => {
-      setLastBlock()
-      startSubscriptions()
-    }, 2000)
-  }
-
-  onConnect(client, dispatch) {
-    if (client.type === 'client') {
-      this.startBlockSubscriptions(client, dispatch)
-    }
-  }
-
-  async startNewHeadsSubscription(client, dispatch) {
-    client.rpc('eth_subscribe', ['newHeads']).then(subscriptionId => {
-      this.newHeadsSubscriptionId = subscriptionId
-      client.on('notification', result => {
-        const { subscription } = result
-        if (subscription === this.newHeadsSubscriptionId) {
-          this.onNewHeadsSubscriptionResult(client, result, dispatch)
-        }
-      })
-    })
-  }
-
-  async startSyncingSubscription(client, dispatch) {
-    console.log('∆∆∆ startSyncingSubscription')
-    const subscriptionId = await client.rpc('eth_subscribe', ['syncing'])
-    this.syncingSubscriptionId = subscriptionId
-    client.on('notification', result => {
-      const { subscription } = result
-      if (subscription === this.newHeadsSubscriptionId) {
-        console.log('∆∆∆ subscriptionId syncing', subscriptionId, result)
-        this.onSyncingSubscriptionResult(client, result, dispatch)
-      }
-    })
   }
 }
 
-export default new ClientService()
+export default new PluginService()

--- a/src/store/plugin/pluginService.js
+++ b/src/store/plugin/pluginService.js
@@ -48,7 +48,7 @@ class PluginService {
     plugin.removeListener('newState', this.newStateListener)
     plugin.removeListener('pluginError', this.pluginErrorListener)
     if (plugin.type === 'client') {
-      clearInterval(this.peerCountInterval)
+      ClientService.clearPeerCountInterval()
       ClientService.unsubscribeSyncingSubscription(plugin)
       ClientService.unsubscribeNewHeadsSubscription(plugin)
     }


### PR DESCRIPTION
#### What does it do?
Simplifies PluginService by refactoring away the client funcs into a separate ClientService file