### PR TITLE
chore: refactor service to plugin

### DIFF
--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/FormItem.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/FormItem.js
@@ -174,10 +174,10 @@ class DynamicConfigFormItem extends Component {
 }
 
 function mapStateToProps(state, ownProps) {
-  const selectedClient = state.plugin.selected
+  const selectedPlugin = state.plugin.selected
 
   return {
-    itemValue: state.plugin[selectedClient].config[ownProps.itemKey]
+    itemValue: state.plugin[selectedPlugin].config[ownProps.itemKey]
   }
 }
 

--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/index.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/index.js
@@ -20,9 +20,11 @@ class DynamicConfigForm extends Component {
     super(props)
 
     const { plugin } = props
-    const clientPlugin = window.Grid.PluginHost.getPluginByName(plugin.selected)
+    const preloadPlugin = window.Grid.PluginHost.getPluginByName(
+      plugin.selected
+    )
     const { config, flags } = plugin[plugin.selected]
-    const generatedFlags = getGeneratedFlags(clientPlugin, config)
+    const generatedFlags = getGeneratedFlags(preloadPlugin, config)
     const flagsIsCustom = !flags.every(f => generatedFlags.includes(f))
     this.state = {
       editGeneratedFlags: flagsIsCustom
@@ -32,10 +34,12 @@ class DynamicConfigForm extends Component {
   toggleEditGeneratedFlags = checked => {
     const { plugin, dispatch } = this.props
     const { config } = plugin[plugin.selected]
-    const clientPlugin = window.Grid.PluginHost.getPluginByName(plugin.selected)
+    const preloadPlugin = window.Grid.PluginHost.getPluginByName(
+      plugin.selected
+    )
     this.setState({ editGeneratedFlags: checked })
     if (!checked) {
-      dispatch(setFlags(clientPlugin, config))
+      dispatch(setFlags(preloadPlugin, config))
     }
   }
 

--- a/src/components/Plugins/PluginConfig/index.js
+++ b/src/components/Plugins/PluginConfig/index.js
@@ -46,12 +46,12 @@ class PluginConfig extends Component {
   componentDidUpdate(prevProps) {
     const { plugin, pluginStatus } = this.props
 
-    // On client start, show Terminal
+    // On plugin start, show Terminal
     if (prevProps.pluginStatus === 'STOPPED' && pluginStatus !== 'STOPPED') {
       this.handleTabChange(null, 2)
     }
 
-    // If switching clients, reset tab to VersionList
+    // If switching plugins, reset tab to VersionList
     if (prevProps.plugin.name !== plugin.name) {
       this.handleTabChange(null, 0)
     }
@@ -155,7 +155,7 @@ class PluginConfig extends Component {
         )}
 
         <TabContainer style={{ display: selectedTab === 2 ? 'block' : 'none' }}>
-          <Terminal client={plugin} />
+          <Terminal plugin={plugin} />
         </TabContainer>
 
         {selectedTab === 3 && (
@@ -169,12 +169,12 @@ class PluginConfig extends Component {
 }
 
 function mapStateToProps(state) {
-  const selectedClient = state.plugin.selected
+  const selectedPlugin = state.plugin.selected
 
   return {
-    pluginStatus: state.plugin[selectedClient].active.status,
-    errors: state.plugin[selectedClient].errors,
-    isActivePlugin: state.plugin[selectedClient].active.name !== 'STOPPED',
+    pluginStatus: state.plugin[selectedPlugin].active.status,
+    errors: state.plugin[selectedPlugin].errors,
+    isActivePlugin: state.plugin[selectedPlugin].active.name !== 'STOPPED',
     selectedTab: state.plugin.selectedTab
   }
 }

--- a/src/components/Plugins/PluginsNav.js
+++ b/src/components/Plugins/PluginsNav.js
@@ -5,7 +5,7 @@ import { withStyles } from '@material-ui/core/styles'
 import Drawer from '@material-ui/core/Drawer'
 import List from '@material-ui/core/List'
 import ListSubheader from '@material-ui/core/ListSubheader'
-import ServicesNavListItem from './ServicesNavListItem'
+import PluginsNavListItem from './PluginsNavListItem'
 
 const drawerWidth = 240
 
@@ -30,36 +30,36 @@ const styles = theme => ({
   }
 })
 
-class ServicesTab extends Component {
+class PluginsNav extends Component {
   static propTypes = {
     classes: PropTypes.object.isRequired,
-    clients: PropTypes.array.isRequired,
-    clientState: PropTypes.object.isRequired,
+    plugins: PropTypes.array.isRequired,
+    pluginState: PropTypes.object.isRequired,
     children: PropTypes.node,
     handleToggle: PropTypes.func.isRequired,
-    handleSelectClient: PropTypes.func.isRequired,
-    selectedClientName: PropTypes.string
+    handleSelectPlugin: PropTypes.func.isRequired,
+    selectedPluginName: PropTypes.string
   }
 
-  isDisabled = client => {
-    const { clientState } = this.props
-    return !clientState[client.name].release.version
+  isDisabled = plugin => {
+    const { pluginState } = this.props
+    return !pluginState[plugin.name].release.version
   }
 
-  isRunning = client => {
-    const { clientState } = this.props
+  isRunning = plugin => {
+    const { pluginState } = this.props
     return ['STARTING', 'STARTED', 'CONNECTED'].includes(
-      clientState[client.name].active.status
+      pluginState[plugin.name].active.status
     )
   }
 
-  buildListItem = client => {
+  buildListItem = plugin => {
     const {
       classes,
-      clientState,
+      pluginState,
       handleToggle,
-      handleSelectClient,
-      selectedClientName
+      handleSelectPlugin,
+      selectedPluginName
     } = this.props
 
     const {
@@ -72,23 +72,23 @@ class ServicesTab extends Component {
     } = classes
 
     return (
-      <ServicesNavListItem
-        key={client.name}
-        client={client}
+      <PluginsNavListItem
+        key={plugin.name}
+        plugin={plugin}
         classes={restClasses}
         handleToggle={handleToggle}
-        handleSelectClient={handleSelectClient}
-        isRunning={this.isRunning(client)}
-        isDisabled={this.isDisabled(client)}
-        isSelected={client.name === selectedClientName}
-        secondaryText={clientState[client.name].release.version || ''}
+        handleSelectPlugin={handleSelectPlugin}
+        isRunning={this.isRunning(plugin)}
+        isDisabled={this.isDisabled(plugin)}
+        isSelected={plugin.name === selectedPluginName}
+        secondaryText={pluginState[plugin.name].release.version || ''}
       />
     )
   }
 
   renderLists = () => {
-    const { clients, classes } = this.props
-    const types = [...new Set(clients.map(client => client.type))]
+    const { plugins, classes } = this.props
+    const types = [...new Set(plugins.map(plugin => plugin.type))]
     const buildList = type => (
       <List
         key={type}
@@ -98,20 +98,20 @@ class ServicesTab extends Component {
           </ListSubheader>
         }
       >
-        {this.renderClients(type)}
+        {this.renderPlugins(type)}
       </List>
     )
     const render = types.map(type => buildList(type))
     return render
   }
 
-  renderClients = type => {
-    const { clients } = this.props
-    const renderClients = clients
-      .filter(client => client.type === type)
+  renderPlugins = type => {
+    const { plugins } = this.props
+    const renderPlugins = plugins
+      .filter(plugin => plugin.type === type)
       .sort((a, b) => a.order - b.order)
       .map(s => this.buildListItem(s))
-    return renderClients
+    return renderPlugins
   }
 
   render() {
@@ -135,9 +135,9 @@ class ServicesTab extends Component {
 
 function mapStateToProps(state) {
   return {
-    clientState: state.plugin,
-    selectedClientName: state.plugin.selected
+    pluginState: state.plugin,
+    selectedPluginName: state.plugin.selected
   }
 }
 
-export default connect(mapStateToProps)(withStyles(styles)(ServicesTab))
+export default connect(mapStateToProps)(withStyles(styles)(PluginsNav))

--- a/src/components/Plugins/PluginsNavListItem.js
+++ b/src/components/Plugins/PluginsNavListItem.js
@@ -8,7 +8,7 @@ import Switch from '@material-ui/core/Switch'
 import Tooltip from '@material-ui/core/Tooltip'
 
 const styles = () => ({
-  serviceName: {
+  pluginName: {
     marginRight: 5,
     textTransform: 'capitalize'
   },
@@ -23,14 +23,12 @@ const styles = () => ({
   }
 })
 
-class ServicesNavListItem extends Component {
-  static displayName = 'ServicesNavListItem'
-
+class PluginsNavListItem extends Component {
   static propTypes = {
     classes: PropTypes.object.isRequired,
-    client: PropTypes.object.isRequired,
+    plugin: PropTypes.object.isRequired,
     handleToggle: PropTypes.func.isRequired,
-    handleSelectClient: PropTypes.func.isRequired,
+    handleSelectPlugin: PropTypes.func.isRequired,
     isDisabled: PropTypes.bool,
     isRunning: PropTypes.bool,
     isSelected: PropTypes.bool,
@@ -41,32 +39,32 @@ class ServicesNavListItem extends Component {
     const {
       classes,
       handleToggle,
-      handleSelectClient,
+      handleSelectPlugin,
       isDisabled,
       isRunning,
       isSelected,
       secondaryText,
-      client
+      plugin
     } = this.props
 
     return (
       <ListItem
-        key={client.name}
+        key={plugin.name}
         selected={isSelected}
-        onClick={() => handleSelectClient(client)}
+        onClick={() => handleSelectPlugin(plugin)}
         classes={{
           root: classes.hoverableListItem,
           selected: classes.selected
         }}
         button
-        data-test-id={`node-${client.name}`}
+        data-test-id={`node-${plugin.name}`}
       >
         <ListItemText
-          primary={client.displayName}
+          primary={plugin.displayName}
           secondary={secondaryText}
           primaryTypographyProps={{
             inline: true,
-            classes: { root: classes.serviceName }
+            classes: { root: classes.pluginName }
           }}
           secondaryTypographyProps={{
             inline: true,
@@ -81,10 +79,10 @@ class ServicesNavListItem extends Component {
             <span>
               <Switch
                 color="primary"
-                onChange={() => handleToggle(client)}
+                onChange={() => handleToggle(plugin)}
                 checked={isRunning}
                 disabled={isDisabled}
-                data-test-id={`switch-${client.name}`}
+                data-test-id={`switch-${plugin.name}`}
               />
             </span>
           </Tooltip>
@@ -94,4 +92,4 @@ class ServicesNavListItem extends Component {
   }
 }
 
-export default withStyles(styles)(ServicesNavListItem)
+export default withStyles(styles)(PluginsNavListItem)

--- a/src/components/Plugins/Terminal/TerminalInput.js
+++ b/src/components/Plugins/Terminal/TerminalInput.js
@@ -29,7 +29,7 @@ const styles = () => ({
 
 class TerminalInput extends Component {
   static propTypes = {
-    client: PropTypes.object.isRequired,
+    plugin: PropTypes.object.isRequired,
     addNewLog: PropTypes.func,
     classes: PropTypes.object
   }
@@ -77,9 +77,9 @@ class TerminalInput extends Component {
   }
 
   submit = () => {
-    const { client, addNewLog } = this.props
+    const { plugin, addNewLog } = this.props
     const { input, history, protectInput } = this.state
-    client.write(input)
+    plugin.write(input)
     addNewLog(protectInput ? '***' : input)
     this.setState({ input: '', historyIndex: 0 })
     // Add to history if not same as last history entry
@@ -90,12 +90,12 @@ class TerminalInput extends Component {
   }
 
   render() {
-    const { classes, client } = this.props
+    const { classes, plugin } = this.props
     const { input, protectInput } = this.state
 
-    const isClientRunning = ['STARTED', 'CONNECTED'].includes(client.state)
+    const isPluginRunning = ['STARTED', 'CONNECTED'].includes(plugin.state)
 
-    if (!isClientRunning) {
+    if (!isPluginRunning) {
       return null
     }
 
@@ -107,7 +107,7 @@ class TerminalInput extends Component {
             value={input}
             onChange={this.handleChange}
             onKeyDown={this.handleKeyDown}
-            disabled={!isClientRunning}
+            disabled={!isPluginRunning}
             className={classes.textField}
             type={protectInput ? 'password' : 'text'}
             InputProps={{

--- a/src/components/Plugins/Terminal/index.js
+++ b/src/components/Plugins/Terminal/index.js
@@ -26,7 +26,7 @@ const styles = () => ({
 
 class Terminal extends Component {
   static propTypes = {
-    client: PropTypes.object.isRequired,
+    plugin: PropTypes.object.isRequired,
     classes: PropTypes.object
   }
 
@@ -42,13 +42,13 @@ class Terminal extends Component {
     this.subscribeLogs()
   }
 
-  componentWillReceiveProps({ client: nextClient }) {
-    const { client: oldClient } = this.props
-    const logs = nextClient.getLogs()
+  componentWillReceiveProps({ plugin: nextPlugin }) {
+    const { plugin: oldPlugin } = this.props
+    const logs = nextPlugin.getLogs()
     this.setState({ logs })
-    if (oldClient && nextClient !== oldClient) {
-      this.unsubscribeLogs(oldClient)
-      this.subscribeLogs(nextClient)
+    if (oldPlugin && nextPlugin !== oldPlugin) {
+      this.unsubscribeLogs(oldPlugin)
+      this.subscribeLogs(nextPlugin)
     }
   }
 
@@ -73,19 +73,19 @@ class Terminal extends Component {
     }
   }
 
-  subscribeLogs = client => {
+  subscribeLogs = plugin => {
     // eslint-disable-next-line
-    client = client || this.props.client
-    client.on('log', this.addNewLog)
+    plugin = plugin || this.props.plugin
+    plugin.on('log', this.addNewLog)
     // Clear old logs on restart
-    client.on('newState', this.clearLogs)
+    plugin.on('newState', this.clearLogs)
   }
 
-  unsubscribeLogs = client => {
+  unsubscribeLogs = plugin => {
     // eslint-disable-next-line
-    client = client || this.props.client
-    client.removeListener('log', this.addNewLog)
-    client.removeListener('newState', this.clearLogs)
+    plugin = plugin || this.props.plugin
+    plugin.removeListener('log', this.addNewLog)
+    plugin.removeListener('newState', this.clearLogs)
   }
 
   terminalScrollToBottom = () => {
@@ -101,7 +101,7 @@ class Terminal extends Component {
   }
 
   render() {
-    const { classes, client } = this.props
+    const { classes, plugin } = this.props
     const { logs } = this.state
 
     if (logs.length === 0) {
@@ -124,7 +124,7 @@ class Terminal extends Component {
         >
           {renderLogs}
         </div>
-        <TerminalInput client={client} addNewLog={this.addNewLog} />
+        <TerminalInput plugin={plugin} addNewLog={this.addNewLog} />
       </div>
     )
   }

--- a/src/components/Plugins/index.js
+++ b/src/components/Plugins/index.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import PluginConfig from './PluginConfig'
-import ServicesNav from './ServicesNav'
+import PluginsNav from './PluginsNav'
 import {
   initPlugin,
   selectPlugin,
@@ -96,10 +96,10 @@ class PluginsTab extends Component {
     const { plugins, selectedPlugin, selectedRelease } = this.state
 
     return (
-      <ServicesNav
+      <PluginsNav
         handleToggle={this.handleToggle}
-        handleSelectClient={this.handleSelectPlugin}
-        clients={plugins}
+        handleSelectPlugin={this.handleSelectPlugin}
+        plugins={plugins}
       >
         {selectedPlugin && (
           <PluginConfig
@@ -109,7 +109,7 @@ class PluginsTab extends Component {
             handleReleaseSelect={this.handleReleaseSelect}
           />
         )}
-      </ServicesNav>
+      </PluginsNav>
     )
   }
 }

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -33,18 +33,18 @@ export const without = (...omitProps) => {
   }
 }
 
-export const getPluginSettingsConfig = client => {
+export const getPluginSettingsConfig = plugin => {
   try {
-    const settings = client.plugin.config.settings // eslint-disable-line
+    const settings = plugin.plugin.config.settings // eslint-disable-line
     return Array.isArray(settings) ? settings : []
   } catch (e) {
     return []
   }
 }
 
-export const getDefaultSetting = (client, id) => {
+export const getDefaultSetting = (plugin, id) => {
   try {
-    const setting = client.plugin.config.settings.find(
+    const setting = plugin.plugin.config.settings.find(
       setting => setting.id === id
     )
     return setting.default
@@ -53,27 +53,27 @@ export const getDefaultSetting = (client, id) => {
   }
 }
 
-export const getSettingsIds = client => {
+export const getSettingsIds = plugin => {
   try {
-    return client.plugin.config.settings.map(setting => setting.id)
+    return plugin.plugin.config.settings.map(setting => setting.id)
   } catch (e) {
     return []
   }
 }
 
-export const getPersistedPluginSettings = clientName => {
+export const getPersistedPluginSettings = pluginName => {
   try {
     const settings = Grid.Config.getItem('settings')
-    return settings[clientName] || {}
+    return settings[pluginName] || {}
   } catch (e) {
     return {}
   }
 }
 
-export const getPersistedFlags = clientName => {
+export const getPersistedFlags = pluginName => {
   try {
     const flags = Grid.Config.getItem('flags')
-    return flags[clientName] || null
+    return flags[pluginName] || null
   } catch (e) {
     return null
   }

--- a/src/test/settings.test.js
+++ b/src/test/settings.test.js
@@ -6,57 +6,57 @@ import {
 import { generateFlags } from '../lib/flags'
 
 describe('getPluginSettingsConfig', () => {
-  it('returns an empty array if no client', () => {
-    const client = undefined
-    expect(getPluginSettingsConfig(client)).toEqual([])
+  it('returns an empty array if no plugin', () => {
+    const plugin = undefined
+    expect(getPluginSettingsConfig(plugin)).toEqual([])
   })
 
   it('returns an empty array if no settings config', () => {
-    const client = { plugin: { config: {} } }
-    expect(getPluginSettingsConfig(client)).toEqual([])
+    const plugin = { plugin: { config: {} } }
+    expect(getPluginSettingsConfig(plugin)).toEqual([])
   })
 
   it('returns an empty array if settings are not an array', () => {
-    const client = { plugin: { config: { settings: { one: '1', two: '2' } } } }
-    expect(getPluginSettingsConfig(client)).toEqual([])
+    const plugin = { plugin: { config: { settings: { one: '1', two: '2' } } } }
+    expect(getPluginSettingsConfig(plugin)).toEqual([])
   })
 
   it('returns the array of settings', () => {
     const settings = [{ id: 'one' }, { id: 'two' }]
-    const client = { plugin: { config: { settings } } }
-    expect(getPluginSettingsConfig(client)).toEqual(settings)
+    const plugin = { plugin: { config: { settings } } }
+    expect(getPluginSettingsConfig(plugin)).toEqual(settings)
   })
 })
 
 describe('getDefaultSetting', () => {
-  it('returns an empty string if no client', () => {
-    const client = undefined
-    expect(getDefaultSetting(client, 'network')).toEqual('')
+  it('returns an empty string if no plugin', () => {
+    const plugin = undefined
+    expect(getDefaultSetting(plugin, 'network')).toEqual('')
   })
 
   it('returns an empty string if no id', () => {
     const settings = [{ id: 'one', default: 'a' }, { id: 'two', default: 'b' }]
-    const client = { plugin: { config: { settings } } }
-    expect(getDefaultSetting(client, undefined)).toEqual('')
+    const plugin = { plugin: { config: { settings } } }
+    expect(getDefaultSetting(plugin, undefined)).toEqual('')
   })
 
   it('returns the default value', () => {
     const settings = [{ id: 'one', default: 'a' }, { id: 'two', default: 'b' }]
-    const client = { plugin: { config: { settings } } }
-    expect(getDefaultSetting(client, 'two')).toEqual('b')
+    const plugin = { plugin: { config: { settings } } }
+    expect(getDefaultSetting(plugin, 'two')).toEqual('b')
   })
 })
 
 describe('getSettingsIds', () => {
-  it('returns an empty array if no client', () => {
-    const client = undefined
-    expect(getSettingsIds(client)).toEqual([])
+  it('returns an empty array if no plugin', () => {
+    const plugin = undefined
+    expect(getSettingsIds(plugin)).toEqual([])
   })
 
   it('returns an array of ids', () => {
     const settings = [{ id: 'one', default: 'a' }, { id: 'two', default: 'b' }]
-    const client = { plugin: { config: { settings } } }
-    expect(getSettingsIds(client)).toEqual(['one', 'two'])
+    const plugin = { plugin: { config: { settings } } }
+    expect(getSettingsIds(plugin)).toEqual(['one', 'two'])
   })
 })
 


### PR DESCRIPTION
#### What does it do?
- `ServicesNav` -> `PluginsNav`
- `ServicesNavListItem` -> `PluginsNavListItem`
- utils refactor
- settings test refactor
- etc. `client`/`service` -> `plugin` refactors.
#### Any helpful background information?
Finishes this task, with the exception of NodeInfo components, which @ryanio has addressed in another PR.
#### Does it close any issues?
Closes https://github.com/ethereum/grid/issues/394