### PR TITLE
fix: disable FlagPreview on running

### DIFF
--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/FlagPreview.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/FlagPreview.js
@@ -44,7 +44,7 @@ class FlagPreview extends Component {
             variant="outlined"
             value={flags.join(' ')}
             onChange={this.handleChange}
-            disabled={!isEditingFlags}
+            disabled={isPluginRunning || !isEditingFlags}
             fullWidth
           />
           <FormControlLabel


### PR DESCRIPTION
#### What does it do?
Small bug fix, I noticed FlagPreview wasn't being disabled while the plugin was running.