### PR TITLE
feat: About tab

### DIFF
--- a/src/components/Apps/AppItem.js
+++ b/src/components/Apps/AppItem.js
@@ -13,7 +13,8 @@ import Grid from '../../API/Grid'
 
 const styles = {
   card: {
-    minWidth: 275
+    minWidth: 275,
+    background: '#222428'
   },
   media: {
     height: 0,
@@ -47,6 +48,8 @@ class AppItem extends React.Component {
         <CardHeader
           title={name}
           subheader={moment(lastUpdated).format('MMMM Do YYYY')}
+          titleTypographyProps={{ style: { fontSize: '22px' } }}
+          subheaderTypographyProps={{ style: { fontSize: '14px' } }}
         />
         <CardMedia className={classes.media} image={screenshot} />
         <CardContent>

--- a/src/components/Plugins/PluginConfig/AboutPlugin.js
+++ b/src/components/Plugins/PluginConfig/AboutPlugin.js
@@ -110,6 +110,9 @@ class AboutPlugin extends Component {
   render() {
     const { plugin, classes } = this.props
     const { about } = plugin
+
+    if (!about) return <p>Plugin has no about data.</p>
+
     const { description, links, community, docs } = about
     return (
       <div>

--- a/src/components/Plugins/PluginConfig/AboutPlugin.js
+++ b/src/components/Plugins/PluginConfig/AboutPlugin.js
@@ -76,9 +76,15 @@ class AboutPlugin extends Component {
         {apps.map(app => {
           const gridApp = gridApps.find(thisApp => thisApp.url === app.url)
           if (gridApp) {
+            // Overwrite `dependencies` key with one specified in plugin so
+            // plugin can have priority in launching with its own settings.
+            const finalApp = { ...gridApp }
+            if (app.dependencies) {
+              finalApp.dependencies = app.dependencies
+            }
             return (
-              <Grid item xs={6} key={app.name}>
-                <AppItem app={gridApp} />
+              <Grid item xs={6} key={gridApp.name}>
+                <AppItem app={finalApp} />
               </Grid>
             )
           }

--- a/src/components/Plugins/PluginConfig/AboutPlugin.js
+++ b/src/components/Plugins/PluginConfig/AboutPlugin.js
@@ -1,0 +1,147 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import PropTypes from 'prop-types'
+import { withStyles } from '@material-ui/core/styles'
+import Typography from '@material-ui/core/Typography'
+import Grid from '@material-ui/core/Grid'
+import GridAPI from '../../../API/Grid'
+import AppItem from '../../Apps/AppItem'
+
+const styles = {
+  spacing: {
+    marginTop: 30
+  },
+  headerText: {
+    fontWeight: 'bold'
+  },
+  link: {
+    display: 'block',
+    color: 'white',
+    textDecoration: 'none',
+    '&:hover': {
+      textDecoration: 'underline'
+    }
+  }
+}
+
+class AboutPlugin extends Component {
+  static propTypes = {
+    plugin: PropTypes.object.isRequired,
+    classes: PropTypes.object.isRequired
+  }
+
+  state = {
+    gridApps: []
+  }
+
+  async componentDidMount() {
+    const gridApps = await GridAPI.AppManager.getAllApps()
+    this.setState({ gridApps })
+  }
+
+  renderLinks(links, name) {
+    const { classes } = this.props
+
+    if (!links) {
+      return null
+    }
+
+    const renderList = links.map(link => (
+      <a href={link.url} className={classes.link} key={link.name}>
+        <Typography variant="body1">{link.name}</Typography>
+      </a>
+    ))
+
+    return (
+      <div>
+        <Typography variant="body1" className={classes.headerText}>
+          {name}
+        </Typography>
+        {renderList}
+      </div>
+    )
+  }
+
+  renderApps() {
+    const { plugin, classes } = this.props
+    const { gridApps } = this.state
+    const { apps } = plugin.about
+
+    if (!apps || !gridApps) {
+      return null
+    }
+
+    const renderList = (
+      <Grid container spacing={24} style={{ marginTop: 0 }}>
+        {apps.map(app => {
+          const gridApp = gridApps.find(thisApp => thisApp.url === app.url)
+          if (gridApp) {
+            return (
+              <Grid item xs={6} key={app.name}>
+                <AppItem app={gridApp} />
+              </Grid>
+            )
+          }
+          return null
+        })}
+      </Grid>
+    )
+
+    return (
+      <div>
+        <Typography
+          variant="body1"
+          className={classes.headerText}
+          style={{ marginTop: 30 }}
+        >
+          Apps
+        </Typography>
+        {renderList}
+      </div>
+    )
+  }
+
+  render() {
+    const { plugin, classes } = this.props
+    const { about } = plugin
+    const { description, links, community, docs } = about
+    return (
+      <div>
+        {description && (
+          <div>
+            <div>
+              <Typography
+                variant="body1"
+                className={classes.headerText}
+                style={{ marginTop: 30 }}
+              >
+                Description
+              </Typography>
+            </div>
+            <div>
+              <Typography variant="body1">{description}</Typography>
+            </div>
+          </div>
+        )}
+        <Grid container spacing={24} style={{ marginTop: 30 }}>
+          <Grid item xs={4}>
+            {this.renderLinks(links, 'Links')}
+          </Grid>
+          <Grid item xs={4}>
+            {this.renderLinks(docs, 'Documentation')}
+          </Grid>
+          <Grid item xs={4}>
+            {this.renderLinks(community, 'Community')}
+          </Grid>
+        </Grid>
+        {this.renderApps()}
+      </div>
+    )
+  }
+}
+
+function mapStateToProps() {
+  return {}
+}
+
+export default connect(mapStateToProps)(withStyles(styles)(AboutPlugin))

--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/FormItem.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/FormItem.js
@@ -177,7 +177,7 @@ function mapStateToProps(state, ownProps) {
   const selectedPlugin = state.plugin.selected
 
   return {
-    itemValue: state.plugin[selectedPlugin].config[ownProps.itemKey]
+    itemValue: state.plugin[selectedPlugin].config[ownProps.itemKey].toString()
   }
 }
 

--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/FormItem.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/FormItem.js
@@ -29,7 +29,7 @@ class DynamicConfigFormItem extends Component {
     // Redux state doesn't need to update on every keystroke.
     this.updateRedux = debounce(this.updateRedux, 500)
     this.state = {
-      fieldValue: props.itemValue
+      fieldValue: (props.itemValue || '').toString()
     }
   }
 
@@ -177,7 +177,7 @@ function mapStateToProps(state, ownProps) {
   const selectedPlugin = state.plugin.selected
 
   return {
-    itemValue: state.plugin[selectedPlugin].config[ownProps.itemKey].toString()
+    itemValue: state.plugin[selectedPlugin].config[ownProps.itemKey]
   }
 }
 

--- a/src/components/Plugins/PluginConfig/index.js
+++ b/src/components/Plugins/PluginConfig/index.js
@@ -8,6 +8,7 @@ import Tab from '@material-ui/core/Tab'
 import Typography from '@material-ui/core/Typography'
 import VersionList from './VersionList'
 import DynamicConfigForm from './DynamicConfigForm'
+import AboutPlugin from './AboutPlugin'
 import Terminal from '../Terminal'
 import NodeInfo from '../NodeInfo'
 import PluginView from '../PluginView'
@@ -44,16 +45,21 @@ class PluginConfig extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { plugin, pluginStatus } = this.props
+    const { plugin, pluginStatus, selectedTab } = this.props
 
     // On plugin start, show Terminal
     if (prevProps.pluginStatus === 'STOPPED' && pluginStatus !== 'STOPPED') {
-      this.handleTabChange(null, 2)
+      this.handleTabChange(null, 3)
     }
 
-    // If switching plugins, reset tab to VersionList
+    // If switching plugins, reset tab to About
+    // (or VersionList if no about is defined)
     if (prevProps.plugin.name !== plugin.name) {
       this.handleTabChange(null, 0)
+    }
+
+    if (!plugin.about && selectedTab === 0) {
+      this.handleTabChange(null, 1)
     }
   }
 
@@ -125,14 +131,27 @@ class PluginConfig extends Component {
             textColor="primary"
             indicatorColor="primary"
           >
+            <Tab
+              label="About"
+              data-test-id="navbar-item-about"
+              style={{ display: plugin.about ? 'block' : 'none' }}
+            />
             <Tab label="Version" data-test-id="navbar-item-version" />
             <Tab label="Settings" data-test-id="navbar-item-settings" />
             <Tab label="Terminal" data-test-id="navbar-item-terminal" />
-            <Tab label="Details" data-test-id="navbar-item-terminal" />
+            <Tab label="Metadata" data-test-id="navbar-item-metadata" />
           </Tabs>
         </StyledAppBar>
 
-        <TabContainer style={{ display: selectedTab === 0 ? 'block' : 'none' }}>
+        {plugin.about && (
+          <TabContainer
+            style={{ display: selectedTab === 0 ? 'block' : 'none' }}
+          >
+            <AboutPlugin plugin={plugin} />
+          </TabContainer>
+        )}
+
+        <TabContainer style={{ display: selectedTab === 1 ? 'block' : 'none' }}>
           <VersionList
             plugin={plugin}
             handleReleaseSelect={handleReleaseSelect}
@@ -140,7 +159,7 @@ class PluginConfig extends Component {
         </TabContainer>
 
         {/* NOTE: MUI requires generating the ConfigForm from state each render */}
-        {selectedTab === 1 && (
+        {selectedTab === 2 && (
           <TabContainer>
             <ErrorBoundary>
               <DynamicConfigForm
@@ -154,11 +173,11 @@ class PluginConfig extends Component {
           </TabContainer>
         )}
 
-        <TabContainer style={{ display: selectedTab === 2 ? 'block' : 'none' }}>
+        <TabContainer style={{ display: selectedTab === 3 ? 'block' : 'none' }}>
           <Terminal plugin={plugin} />
         </TabContainer>
 
-        {selectedTab === 3 && (
+        {selectedTab === 4 && (
           <TabContainer>
             <PluginView plugin={plugin} />
           </TabContainer>

--- a/src/components/Plugins/PluginConfig/index.js
+++ b/src/components/Plugins/PluginConfig/index.js
@@ -45,7 +45,7 @@ class PluginConfig extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { plugin, pluginStatus, selectedTab } = this.props
+    const { plugin, pluginStatus } = this.props
 
     // On plugin start, show Terminal
     if (prevProps.pluginStatus === 'STOPPED' && pluginStatus !== 'STOPPED') {
@@ -53,13 +53,8 @@ class PluginConfig extends Component {
     }
 
     // If switching plugins, reset tab to About
-    // (or VersionList if no about is defined)
     if (prevProps.plugin.name !== plugin.name) {
       this.handleTabChange(null, 0)
-    }
-
-    if (!plugin.about && selectedTab === 0) {
-      this.handleTabChange(null, 1)
     }
   }
 
@@ -131,11 +126,7 @@ class PluginConfig extends Component {
             textColor="primary"
             indicatorColor="primary"
           >
-            <Tab
-              label="About"
-              data-test-id="navbar-item-about"
-              style={{ display: plugin.about ? 'block' : 'none' }}
-            />
+            <Tab label="About" data-test-id="navbar-item-about" />
             <Tab label="Version" data-test-id="navbar-item-version" />
             <Tab label="Settings" data-test-id="navbar-item-settings" />
             <Tab label="Terminal" data-test-id="navbar-item-terminal" />
@@ -143,13 +134,9 @@ class PluginConfig extends Component {
           </Tabs>
         </StyledAppBar>
 
-        {plugin.about && (
-          <TabContainer
-            style={{ display: selectedTab === 0 ? 'block' : 'none' }}
-          >
-            <AboutPlugin plugin={plugin} />
-          </TabContainer>
-        )}
+        <TabContainer style={{ display: selectedTab === 0 ? 'block' : 'none' }}>
+          <AboutPlugin plugin={plugin} />
+        </TabContainer>
 
         <TabContainer style={{ display: selectedTab === 1 ? 'block' : 'none' }}>
           <VersionList
@@ -157,7 +144,6 @@ class PluginConfig extends Component {
             handleReleaseSelect={handleReleaseSelect}
           />
         </TabContainer>
-
         {/* NOTE: MUI requires generating the ConfigForm from state each render */}
         {selectedTab === 2 && (
           <TabContainer>
@@ -172,11 +158,9 @@ class PluginConfig extends Component {
             </ErrorBoundary>
           </TabContainer>
         )}
-
         <TabContainer style={{ display: selectedTab === 3 ? 'block' : 'none' }}>
           <Terminal plugin={plugin} />
         </TabContainer>
-
         {selectedTab === 4 && (
           <TabContainer>
             <PluginView plugin={plugin} />

--- a/src/store/plugin/actions.js
+++ b/src/store/plugin/actions.js
@@ -137,7 +137,7 @@ export const clearError = (pluginName, index) => {
   }
 }
 
-export const selectPlugin = (pluginName, tab = 0) => {
+export const selectPlugin = (pluginName, tab) => {
   return { type: 'PLUGIN:SELECT', payload: { pluginName, tab } }
 }
 

--- a/src/store/plugin/reducer.js
+++ b/src/store/plugin/reducer.js
@@ -71,7 +71,11 @@ const plugin = (state = initialState, action) => {
     }
     case 'PLUGIN:SELECT': {
       const { pluginName, tab } = action.payload
-      return { ...state, selected: pluginName, selectedTab: tab }
+      const newState = { ...state, selected: pluginName }
+      if (tab) {
+        newState.selectedTab = tab
+      }
+      return newState
     }
     case 'PLUGIN:SELECT_TAB': {
       const { tab } = action.payload


### PR DESCRIPTION
#### What does it do?
* Adds an `About` tab as the first tab on plugins
* Renames `Details` tab to `Metadata`

---

To be paired with https://github.com/ethereum/grid/pull/426

---

#### Screenshots:

<img width="1212" alt="Screen Shot 2019-08-21 at 9 47 21 PM" src="https://user-images.githubusercontent.com/22116/63486654-4a5b2280-c45d-11e9-8040-caa1789923ee.png">
<img width="1224" alt="Screen Shot 2019-08-21 at 8 09 46 PM" src="https://user-images.githubusercontent.com/22116/63486615-1da70b00-c45d-11e9-8ecc-1ea042b8ffc0.png">
<img width="1233" alt="Screen Shot 2019-08-21 at 8 22 15 PM" src="https://user-images.githubusercontent.com/22116/63486625-2d265400-c45d-11e9-8f1e-2db6c9b2992c.png">
<img width="1241" alt="Screen Shot 2019-08-21 at 8 22 21 PM" src="https://user-images.githubusercontent.com/22116/63486617-1f70ce80-c45d-11e9-958b-03106e7bd0af.png">
        
---

Closes https://github.com/ethereum/grid/issues/422