### PR TITLE
chore: bump grid-ui version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grid-ui",
-  "version": "0.1.30",
+  "version": "0.1.40",
   "private": true,
   "main": "./app/shell-electron.js",
   "homepage": "./",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grid-ui",
-  "version": "0.1.40",
+  "version": "0.1.31",
   "private": true,
   "main": "./app/shell-electron.js",
   "homepage": "./",


### PR DESCRIPTION
#### What does it do?
Bumps `grid-ui` version to `0.1.31`