### PR TITLE
feat: omits required settings from form UI

### DIFF
--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/index.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/index.js
@@ -80,7 +80,10 @@ class DynamicConfigForm extends Component {
 
     if (!settings) return <h4>No configuration settings found</h4>
 
-    const formItems = settings.map(this.wrapFormItem).map(this.wrapGridItem)
+    const formItems = settings
+      .filter(setting => !setting.required) // Omit required flags from UI
+      .map(this.wrapFormItem)
+      .map(this.wrapGridItem)
 
     return (
       <div>


### PR DESCRIPTION
#### What does it do?
Introduces `required` flags. Half of closing https://github.com/ethereum/grid/issues/442
#### Any helpful background information?
I like this solution because: 
A) the plugin config code is a little verbose, but requires no changes to the complicated flag generation logic, and 
B) users can still go wild and override the flags in the custom flag section

Note: assuming you have some stored values for Parity configs, you will likely have to toggle custom flags on and off to see the new ones appear.
#### Relevant screenshots?
<img width="1212" alt="Screen Shot 2019-08-28 at 4 17 39 PM" src="https://user-images.githubusercontent.com/3621728/63896492-61df6180-c9af-11e9-8cec-794e129099d6.png">
