### PR TITLE
fix: excess width in metadata

### DIFF
--- a/src/components/Plugins/PluginView/index.js
+++ b/src/components/Plugins/PluginView/index.js
@@ -12,21 +12,9 @@ require('codemirror/mode/javascript/javascript')
 
 const styles = () => ({
   terminalWrapper: {
-    background: '#111',
-    color: '#eee',
-    fontFamily:
-      'Lucida Console, Lucida Sans Typewriter, monaco, Bitstream Vera Sans Mono, monospace',
-    fontSize: '11px',
-    padding: 10,
-
     // Fluid width and height with support to scrolling
     width: 'calc(100vw - 310px)',
-    height: 'calc(100vh - 274px)',
-
-    // Scroll config
-    overflowX: 'auto',
-    overflowY: 'scroll',
-    whiteSpace: 'nowrap'
+    height: 'calc(100vh - 274px)'
   }
 })
 
@@ -152,7 +140,7 @@ class PluginView extends Component {
   }
 
   render() {
-    const { plugin } = this.props
+    const { classes, plugin } = this.props
     const { metadata } = plugin
 
     return (
@@ -167,6 +155,7 @@ class PluginView extends Component {
         )}
         <h3 style={{ color: 'grey' }}>Plugin Code</h3>
         <CodeMirror
+          className={classes.terminalWrapper}
           value={plugin.source}
           options={{
             mode: 'javascript',


### PR DESCRIPTION
#### What does it do?
Fixes horizontal scrolling bug when `Metadata` tab is selected.
#### Any helpful background information?
Styles from the Terminal component were copy-pasted into this component, but never applied.
#### Relevant screenshots?
<img width="1212" alt="Screen Shot 2019-08-30 at 10 04 53 AM" src="https://user-images.githubusercontent.com/3621728/64038760-24491880-cb16-11e9-966b-c4b8626ea609.png">

#### Does it close any issues?
Closes https://github.com/ethereum/grid/issues/373