### PR TITLE
feat: clearPluginErrors for nano

### DIFF
--- a/src/components/Plugins/PluginConfig/index.js
+++ b/src/components/Plugins/PluginConfig/index.js
@@ -5,6 +5,7 @@ import styled from 'styled-components'
 import AppBar from '@material-ui/core/AppBar'
 import Tabs from '@material-ui/core/Tabs'
 import Tab from '@material-ui/core/Tab'
+import Badge from '@material-ui/core/Badge'
 import Typography from '@material-ui/core/Typography'
 import VersionList from './VersionList'
 import DynamicConfigForm from './DynamicConfigForm'
@@ -40,7 +41,7 @@ class PluginConfig extends Component {
     isActivePlugin: PropTypes.bool,
     handleReleaseSelect: PropTypes.func,
     handlePluginConfigChanged: PropTypes.func,
-    errors: PropTypes.array,
+    pluginErrors: PropTypes.array,
     selectedTab: PropTypes.number
   }
 
@@ -61,6 +62,10 @@ class PluginConfig extends Component {
   handleTabChange = (event, tab) => {
     const { dispatch } = this.props
     dispatch(selectTab(tab))
+    // Clear errors if going to Terminal tab
+    if (tab === 3) {
+      this.clearPluginErrors()
+    }
   }
 
   handlePluginConfigChanged = (key, value) => {
@@ -71,12 +76,21 @@ class PluginConfig extends Component {
   dismissError = index => {
     const { dispatch, plugin } = this.props
     dispatch(clearError(plugin.name, index))
+    this.clearPluginErrors()
+  }
+
+  clearPluginErrors = () => {
+    // Clear errors in nano
+    const { plugin, pluginErrors } = this.props
+    if (pluginErrors.length > 0) {
+      plugin.emit('clearPluginErrors')
+    }
   }
 
   renderErrors() {
-    const { errors } = this.props
+    const { pluginErrors } = this.props
     const renderErrors = []
-    errors.forEach((error, index) => {
+    pluginErrors.forEach((error, index) => {
       const renderError = (
         <Notification
           key={index}
@@ -100,7 +114,8 @@ class PluginConfig extends Component {
       pluginStatus,
       isActivePlugin,
       handleReleaseSelect,
-      selectedTab
+      selectedTab,
+      pluginErrors
     } = this.props
     const { displayName: pluginName } = plugin || {}
     const isRunning = ['STARTING', 'STARTED', 'CONNECTED'].includes(
@@ -129,7 +144,14 @@ class PluginConfig extends Component {
             <Tab label="About" data-test-id="navbar-item-about" />
             <Tab label="Version" data-test-id="navbar-item-version" />
             <Tab label="Settings" data-test-id="navbar-item-settings" />
-            <Tab label="Terminal" data-test-id="navbar-item-terminal" />
+            <Tab
+              label={
+                <Badge color="error" badgeContent={pluginErrors.length}>
+                  Terminal
+                </Badge>
+              }
+              data-test-id="navbar-item-terminal"
+            />
             <Tab label="Metadata" data-test-id="navbar-item-metadata" />
           </Tabs>
         </StyledAppBar>
@@ -176,7 +198,7 @@ function mapStateToProps(state) {
 
   return {
     pluginStatus: state.plugin[selectedPlugin].active.status,
-    errors: state.plugin[selectedPlugin].errors,
+    pluginErrors: state.plugin[selectedPlugin].errors,
     isActivePlugin: state.plugin[selectedPlugin].active.name !== 'STOPPED',
     selectedTab: state.plugin.selectedTab
   }


### PR DESCRIPTION
#### What does it do?
Fixes https://github.com/ethereum/grid/issues/418

* Dispatches `clearPluginErrors` on Terminal tab click or closing error.
* Adds error count badge on Terminal tab.

Pairs with https://github.com/ethereum/grid/pull/446

![ezgif-3-fd8dcc88d419](https://user-images.githubusercontent.com/22116/64045913-62970580-cb1f-11e9-82b0-a1c912405265.gif)
