### PR TITLE
fix: pulse on new block

### DIFF
--- a/src/components/Plugins/NodeInfo/NodeInfoDot.js
+++ b/src/components/Plugins/NodeInfo/NodeInfoDot.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import styled, { css, keyframes } from 'styled-components'
 import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
 import moment from 'moment'
 import PieChart from 'react-minimal-pie-chart'
 
@@ -15,7 +16,8 @@ class NodeInfoDot extends Component {
     diffTimestamp: PropTypes.number,
     isStopped: PropTypes.bool,
     /** If component is stickied, apply drop shadow on dot */
-    sticky: PropTypes.bool
+    sticky: PropTypes.bool,
+    blockNumber: PropTypes.number
   }
 
   state = {
@@ -23,9 +25,8 @@ class NodeInfoDot extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { plugin } = this.props
-
-    if ((prevProps.plugin.blockNumber || 0) !== (plugin.blockNumber || 0)) {
+    const { props } = this
+    if (props.blockNumber > prevProps.blockNumber) {
       this.pulseForNewBlock()
     }
   }
@@ -115,7 +116,14 @@ class NodeInfoDot extends Component {
   }
 }
 
-export default NodeInfoDot
+function mapStateToProps(state) {
+  return {
+    blockNumber:
+      Number(state.plugin[state.plugin.selected].active.blockNumber) || 0
+  }
+}
+
+export default connect(mapStateToProps)(NodeInfoDot)
 
 const beaconOrange = keyframes`
   0% {

--- a/src/components/Plugins/NodeInfo/NodeInfoDot.js
+++ b/src/components/Plugins/NodeInfo/NodeInfoDot.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react'
 import styled, { css, keyframes } from 'styled-components'
 import PropTypes from 'prop-types'
-import { connect } from 'react-redux'
 import moment from 'moment'
 import PieChart from 'react-minimal-pie-chart'
 
@@ -16,8 +15,7 @@ class NodeInfoDot extends Component {
     diffTimestamp: PropTypes.number,
     isStopped: PropTypes.bool,
     /** If component is stickied, apply drop shadow on dot */
-    sticky: PropTypes.bool,
-    blockNumber: PropTypes.number
+    sticky: PropTypes.bool
   }
 
   state = {
@@ -25,8 +23,10 @@ class NodeInfoDot extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { props } = this
-    if (props.blockNumber > prevProps.blockNumber) {
+    const { plugin } = this.props
+    const { blockNumber: oldBlockNumber } = prevProps.plugin.active
+    const { blockNumber: newBlockNumber } = plugin.active
+    if ((Number(newBlockNumber) || 0) > (Number(oldBlockNumber) || 0)) {
       this.pulseForNewBlock()
     }
   }
@@ -116,14 +116,7 @@ class NodeInfoDot extends Component {
   }
 }
 
-function mapStateToProps(state) {
-  return {
-    blockNumber:
-      Number(state.plugin[state.plugin.selected].active.blockNumber) || 0
-  }
-}
-
-export default connect(mapStateToProps)(NodeInfoDot)
+export default NodeInfoDot
 
 const beaconOrange = keyframes`
   0% {

--- a/src/components/Plugins/NodeInfo/index.js
+++ b/src/components/Plugins/NodeInfo/index.js
@@ -28,6 +28,10 @@ class NodeInfo extends Component {
     }, 1000)
   }
 
+  componentWillUnmount() {
+    clearInterval(this.diffInterval)
+  }
+
   render() {
     const { pluginState, selectedPlugin } = this.props
     const plugin = pluginState[selectedPlugin]

--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/FormItem.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/FormItem.js
@@ -12,7 +12,7 @@ import { Grid as GridAPI } from '../../../../API'
 class DynamicConfigFormItem extends Component {
   static propTypes = {
     itemKey: PropTypes.string,
-    itemValue: PropTypes.string,
+    itemValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     item: PropTypes.object,
     plugin: PropTypes.object,
     pluginName: PropTypes.string,


### PR DESCRIPTION
#### What does it do?
* Restores pulse on new block
* Fixes dynamic config itemValue warning

![pulse](https://user-images.githubusercontent.com/22116/64055403-11980900-cb41-11e9-928d-886f6bf5f58c.gif)