### PR TITLE
feat: App Badges

### DIFF
--- a/src/components/Apps/AppItem.js
+++ b/src/components/Apps/AppItem.js
@@ -14,7 +14,6 @@ import Grid from '../../API/Grid'
 
 const styles = {
   card: {
-    minWidth: 275,
     background: '#222428'
   },
   media: {

--- a/src/components/Apps/AppItem.js
+++ b/src/components/Apps/AppItem.js
@@ -32,6 +32,10 @@ class AppItem extends React.Component {
     badge: PropTypes.number
   }
 
+  static defaultProps = {
+    badge: 0
+  }
+
   state = {}
 
   handleAppLaunch = () => {

--- a/src/components/Apps/AppItem.js
+++ b/src/components/Apps/AppItem.js
@@ -6,6 +6,7 @@ import CardHeader from '@material-ui/core/CardHeader'
 import CardContent from '@material-ui/core/CardContent'
 import CardMedia from '@material-ui/core/CardMedia'
 import CardActions from '@material-ui/core/CardActions'
+import Badge from '@material-ui/core/Badge'
 import Typography from '@material-ui/core/Typography'
 import moment from 'moment'
 import Button from '../shared/Button'
@@ -28,7 +29,8 @@ const styles = {
 class AppItem extends React.Component {
   static propTypes = {
     classes: PropTypes.object.isRequired,
-    app: PropTypes.object
+    app: PropTypes.object,
+    badge: PropTypes.number
   }
 
   state = {}
@@ -39,7 +41,7 @@ class AppItem extends React.Component {
   }
 
   render() {
-    const { classes, app } = this.props
+    const { classes, app, badge } = this.props
 
     const { name, lastUpdated, description, screenshot } = app
 
@@ -56,7 +58,9 @@ class AppItem extends React.Component {
           <Typography component="p">{description}</Typography>
         </CardContent>
         <CardActions>
-          <Button onClick={this.handleAppLaunch}>Launch</Button>
+          <Badge color="secondary" badgeContent={badge}>
+            <Button onClick={this.handleAppLaunch}>Launch</Button>
+          </Badge>
         </CardActions>
       </Card>
     )

--- a/src/components/Plugins/PluginConfig/AboutPlugin.js
+++ b/src/components/Plugins/PluginConfig/AboutPlugin.js
@@ -71,9 +71,8 @@ class AboutPlugin extends Component {
     if (!apps || !gridApps) {
       return null
     }
-
     const renderList = (
-      <Grid container spacing={24} style={{ marginTop: 0 }}>
+      <Grid container spacing={16} style={{ marginTop: 0 }}>
         {apps.map(app => {
           const gridApp = gridApps.find(thisApp => thisApp.url === app.url)
           if (gridApp) {
@@ -88,7 +87,7 @@ class AboutPlugin extends Component {
               badge = pluginState[plugin.name].appBadges[gridApp.id]
             }
             return (
-              <Grid item xs={6} key={gridApp.name}>
+              <Grid item xs={4} key={gridApp.name}>
                 <AppItem app={finalApp} badge={badge} />
               </Grid>
             )

--- a/src/components/Plugins/PluginConfig/AboutPlugin.js
+++ b/src/components/Plugins/PluginConfig/AboutPlugin.js
@@ -27,6 +27,7 @@ const styles = {
 class AboutPlugin extends Component {
   static propTypes = {
     plugin: PropTypes.object.isRequired,
+    pluginState: PropTypes.object.isRequired,
     classes: PropTypes.object.isRequired
   }
 

--- a/src/components/Plugins/PluginConfig/AboutPlugin.js
+++ b/src/components/Plugins/PluginConfig/AboutPlugin.js
@@ -63,7 +63,7 @@ class AboutPlugin extends Component {
   }
 
   renderApps() {
-    const { plugin, classes } = this.props
+    const { plugin, classes, pluginState } = this.props
     const { gridApps } = this.state
     const { apps } = plugin.about
 
@@ -82,9 +82,13 @@ class AboutPlugin extends Component {
             if (app.dependencies) {
               finalApp.dependencies = app.dependencies
             }
+            let badge = 0
+            if (pluginState[plugin.name].appBadges[gridApp.id]) {
+              badge = pluginState[plugin.name].appBadges[gridApp.id]
+            }
             return (
               <Grid item xs={6} key={gridApp.name}>
-                <AppItem app={finalApp} />
+                <AppItem app={finalApp} badge={badge} />
               </Grid>
             )
           }
@@ -149,8 +153,10 @@ class AboutPlugin extends Component {
   }
 }
 
-function mapStateToProps() {
-  return {}
+function mapStateToProps(state) {
+  return {
+    pluginState: state.plugin
+  }
 }
 
 export default connect(mapStateToProps)(withStyles(styles)(AboutPlugin))

--- a/src/components/Plugins/PluginConfig/index.js
+++ b/src/components/Plugins/PluginConfig/index.js
@@ -204,13 +204,13 @@ class PluginConfig extends Component {
 }
 
 function mapStateToProps(state) {
-  const selectedPlugin = state.plugin.selected
+  const { selected } = state.plugin
 
   return {
-    pluginStatus: state.plugin[selectedPlugin].active.status,
-    errors: state.plugin[selectedPlugin].errors,
-    appBadges: state.plugin[selectedPlugin].appBadges,
-    isActivePlugin: state.plugin[selectedPlugin].active.name !== 'STOPPED',
+    pluginStatus: state.plugin[selected].active.status,
+    errors: state.plugin[selected].errors,
+    appBadges: state.plugin[selected].appBadges,
+    isActivePlugin: state.plugin[selected].active.name !== 'STOPPED',
     selectedTab: state.plugin.selectedTab
   }
 }

--- a/src/components/Plugins/PluginConfig/index.js
+++ b/src/components/Plugins/PluginConfig/index.js
@@ -59,7 +59,7 @@ class PluginConfig extends Component {
     const { plugin, pluginStatus } = this.props
 
     // On plugin start, show Terminal
-    if (prevProps.pluginStatus === 'STOPPED' && pluginStatus !== 'STOPPED') {
+    if (prevProps.pluginStatus === 'STOPPED' && pluginStatus === 'STARTING') {
       this.handleTabChange(null, 3)
     }
 

--- a/src/components/Plugins/PluginsNavListItem.js
+++ b/src/components/Plugins/PluginsNavListItem.js
@@ -1,9 +1,11 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
 import { withStyles } from '@material-ui/core/styles'
 import ListItemSecondaryAction from '@material-ui/core/ListItemSecondaryAction'
 import ListItem from '@material-ui/core/ListItem'
 import ListItemText from '@material-ui/core/ListItemText'
+import Badge from '@material-ui/core/Badge'
 import Switch from '@material-ui/core/Switch'
 import Tooltip from '@material-ui/core/Tooltip'
 
@@ -32,7 +34,13 @@ class PluginsNavListItem extends Component {
     isDisabled: PropTypes.bool,
     isRunning: PropTypes.bool,
     isSelected: PropTypes.bool,
-    secondaryText: PropTypes.string
+    secondaryText: PropTypes.string,
+    appBadges: PropTypes.object
+  }
+
+  badgeContent = () => {
+    const { appBadges } = this.props
+    return Object.values(appBadges).reduce((a, b) => a + b, 0)
   }
 
   render() {
@@ -60,7 +68,11 @@ class PluginsNavListItem extends Component {
         data-test-id={`node-${plugin.name}`}
       >
         <ListItemText
-          primary={plugin.displayName}
+          primary={
+            <Badge color="secondary" badgeContent={this.badgeContent()}>
+              {plugin.displayName}
+            </Badge>
+          }
           secondary={secondaryText}
           primaryTypographyProps={{
             inline: true,
@@ -92,4 +104,10 @@ class PluginsNavListItem extends Component {
   }
 }
 
-export default withStyles(styles)(PluginsNavListItem)
+function mapStateToProps(state, ownProps) {
+  return {
+    appBadges: state.plugin[ownProps.plugin.name].appBadges
+  }
+}
+
+export default connect(mapStateToProps)(withStyles(styles)(PluginsNavListItem))

--- a/src/store/plugin/actions.js
+++ b/src/store/plugin/actions.js
@@ -212,3 +212,10 @@ export const togglePlugin = (plugin, release) => {
     }
   }
 }
+
+export const setAppBadges = (plugin, appBadges = {}) => {
+  return {
+    type: 'PLUGIN:SET_APP_BADGES',
+    payload: { pluginName: plugin.name, appBadges }
+  }
+}

--- a/src/store/plugin/pluginService.js
+++ b/src/store/plugin/pluginService.js
@@ -1,5 +1,5 @@
 import ClientService from './clientService'
-import { addPluginError, onConnectionUpdate } from './actions'
+import { addPluginError, onConnectionUpdate, setAppBadges } from './actions'
 
 class PluginService {
   start(plugin, release, flags, config, dispatch) {
@@ -40,13 +40,18 @@ class PluginService {
     this.pluginErrorListener = error =>
       dispatch(addPluginError(plugin.name, error))
 
+    this.setAppBadgeListener = ({ appId, count }) =>
+      dispatch(setAppBadges(plugin, { [appId]: count }))
+
     plugin.on('newState', this.newStateListener)
     plugin.on('pluginError', this.pluginErrorListener)
+    plugin.on('setAppBadge', this.setAppBadgeListener)
   }
 
   removeListeners(plugin) {
     plugin.removeListener('newState', this.newStateListener)
     plugin.removeListener('pluginError', this.pluginErrorListener)
+    plugin.removeListener('setAppBadge', this.setAppBadgeListener)
     if (plugin.type === 'client') {
       ClientService.clearPeerCountInterval()
       ClientService.clearSyncingInterval(plugin)

--- a/src/store/plugin/reducer.js
+++ b/src/store/plugin/reducer.js
@@ -26,6 +26,7 @@ export const initialPluginState = {
   flags: [],
   displayName: '',
   errors: [],
+  appBadges: {},
   name: '',
   prefix: '',
   release: {
@@ -175,6 +176,20 @@ const plugin = (state = initialState, action) => {
           errors: state[pluginName].errors.filter(
             (n, nIndex) => nIndex !== index
           )
+        }
+      }
+    }
+    case 'PLUGIN:SET_APP_BADGES': {
+      const { pluginName, appBadges } = action.payload
+      return {
+        ...state,
+        [pluginName]: {
+          ...initialPluginState,
+          ...state[pluginName],
+          appBadges: {
+            ...state[pluginName].appBadges,
+            ...appBadges
+          }
         }
       }
     }


### PR DESCRIPTION
#### What does it do?
Plugins can now emit `setAppBadge({appId, count})` and provide `plugin.api.getAppBadges()`, to put an app badge over an app.

An app badge object looks like: `{'grid-clef-app': 2}`

<img width="1204" alt="Screen Shot 2019-09-03 at 8 51 24 PM" src="https://user-images.githubusercontent.com/22116/64224535-72b83780-cec7-11e9-9e29-c3f544440cf0.png">

---

Branch pairs with https://github.com/ethereum/grid/pull/227