### PR TITLE
fix: node info position

### DIFF
--- a/src/components/Plugins/NodeInfo/NodeInfoBox.js
+++ b/src/components/Plugins/NodeInfo/NodeInfoBox.js
@@ -207,7 +207,7 @@ export default NodeInfoBox
 const StyledSubmenuContainer = styled.div`
   width: 220px;
   border-radius: 5px;
-  z-index: 1000;
+  z-index: 10000;
   cursor: default;
 
   transition: 150ms linear all, 1ms linear top;
@@ -225,8 +225,8 @@ const StyledSubmenuContainer = styled.div`
 
   /* Apply css arrow to topLeft of box */
   position: absolute;
-  left: 85px;
-  top: 6px;
+  left: 354px;
+  top: 38px;
 
   &::before {
     content: '';

--- a/src/components/Plugins/PluginsNav.js
+++ b/src/components/Plugins/PluginsNav.js
@@ -24,7 +24,7 @@ const styles = theme => ({
     maxHeight: '100%',
     maxWidth: `calc(100% - ${drawerWidth}px)`,
     flexGrow: 1,
-    padding: `${theme.spacing.unit * 1}px ${theme.spacing.unit * 3}px ${theme
+    padding: `${theme.spacing.unit * 4}px ${theme.spacing.unit * 3}px ${theme
       .spacing.unit * 3}px`
     // marginLeft: -drawerWidth
   },


### PR DESCRIPTION
#### What does it do?
Fixes node info positioning with new grid-ui layout. 

It would be ideal to not use absolute positioning so it doesn't break every time the layout changes, but this is a quick fix for now to move onto more important tasks.