### PR TITLE
feat: use notistack

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "ethereum-react-components": "^1.13.11",
     "lodash": "^4.17.13",
     "moment": "^2.24.0",
+    "notistack": "^0.9.0",
     "numeral": "^2.0.6",
     "prop-types": "^15.6.2",
     "react": "^16.4.1",

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { MuiThemeProvider } from '@material-ui/core/styles'
+import { SnackbarProvider } from 'notistack'
 import CssBaseline from '@material-ui/core/CssBaseline'
 import { darkTheme, lightTheme } from '../theme'
 import HelpFab from './shared/HelpFab'
@@ -18,11 +19,20 @@ export default class NewApp extends Component {
     const { themeMode } = this.props
     return (
       <MuiThemeProvider theme={themeMode === 'light' ? lightTheme : darkTheme}>
-        <CssBaseline />
-        <HelpFab />
-        <ErrorBoundary>
-          <Plugins />
-        </ErrorBoundary>
+        <SnackbarProvider
+          maxSnack={10}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'right'
+          }}
+          autoHideDuration={null}
+        >
+          <CssBaseline />
+          <HelpFab />
+          <ErrorBoundary>
+            <Plugins />
+          </ErrorBoundary>
+        </SnackbarProvider>
       </MuiThemeProvider>
     )
   }

--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/FlagPreview.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/FlagPreview.js
@@ -1,7 +1,9 @@
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
+import { withSnackbar } from 'notistack'
 import PropTypes from 'prop-types'
 import TextField from '@material-ui/core/TextField'
+import Button from '@material-ui/core/Button'
 import FormGroup from '@material-ui/core/FormGroup'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import Checkbox from '@material-ui/core/Checkbox'
@@ -9,7 +11,6 @@ import {
   dismissFlagWarning,
   setCustomFlags
 } from '../../../../store/plugin/actions'
-import Notification from '../../../shared/Notification'
 
 class FlagPreview extends Component {
   static propTypes = {
@@ -19,7 +20,39 @@ class FlagPreview extends Component {
     isEditingFlags: PropTypes.bool,
     toggleEditGeneratedFlags: PropTypes.func,
     dispatch: PropTypes.func,
-    showWarning: PropTypes.bool
+    showWarning: PropTypes.bool,
+    enqueueSnackbar: PropTypes.func,
+    closeSnackbar: PropTypes.func
+  }
+
+  componentDidUpdate = () => {
+    const {
+      isEditingFlags,
+      showWarning,
+      enqueueSnackbar,
+      closeSnackbar
+    } = this.props
+    if (isEditingFlags && showWarning) {
+      enqueueSnackbar("Use caution! Don't take flags from strangers.", {
+        variant: 'warning',
+        onClose: () => {
+          this.dismissFlagWarning()
+        },
+        action: key => (
+          <Fragment>
+            <Button
+              style={{ color: '#000' }}
+              onClick={() => {
+                closeSnackbar(key)
+                this.dismissFlagWarning()
+              }}
+            >
+              {'Dismiss'}
+            </Button>
+          </Fragment>
+        )
+      })
+    }
   }
 
   toggleEdit = event => {
@@ -40,7 +73,7 @@ class FlagPreview extends Component {
   }
 
   render() {
-    const { flags, isEditingFlags, isPluginRunning, showWarning } = this.props
+    const { flags, isEditingFlags, isPluginRunning } = this.props
 
     return (
       <React.Fragment>
@@ -67,13 +100,6 @@ class FlagPreview extends Component {
             label="Use custom flags"
           />
         </FormGroup>
-        {isEditingFlags && showWarning && (
-          <Notification
-            type="warning"
-            message="Use caution! Don't take flags from strangers."
-            onDismiss={this.dismissFlagWarning}
-          />
-        )}
       </React.Fragment>
     )
   }
@@ -85,4 +111,4 @@ function mapStateToProps(state) {
   }
 }
 
-export default connect(mapStateToProps)(FlagPreview)
+export default connect(mapStateToProps)(withSnackbar(FlagPreview))

--- a/src/components/Plugins/PluginConfig/index.js
+++ b/src/components/Plugins/PluginConfig/index.js
@@ -2,9 +2,11 @@ import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
+import { withSnackbar } from 'notistack'
 import AppBar from '@material-ui/core/AppBar'
 import Tabs from '@material-ui/core/Tabs'
 import Tab from '@material-ui/core/Tab'
+import Button from '@material-ui/core/Button'
 import Badge from '@material-ui/core/Badge'
 import Typography from '@material-ui/core/Typography'
 import VersionList from './VersionList'
@@ -16,10 +18,10 @@ import PluginView from '../PluginView'
 import {
   clearError,
   selectTab,
-  setAppBadges
+  setAppBadges,
+  getPluginErrors
 } from '../../../store/plugin/actions'
 
-import Notification from '../../shared/Notification'
 import ErrorBoundary from '../../GenericErrorBoundary'
 import { getPluginSettingsConfig } from '../../../lib/utils'
 
@@ -59,12 +61,18 @@ class PluginConfig extends Component {
     handlePluginConfigChanged: PropTypes.func,
     pluginErrors: PropTypes.array,
     appBadges: PropTypes.object,
-    selectedTab: PropTypes.number
+    selectedTab: PropTypes.number,
+    enqueueSnackbar: PropTypes.func,
+    closeSnackbar: PropTypes.func
   }
 
   constructor(props) {
     super(props)
+    this.state = {
+      displayedErrors: {}
+    }
     this.getAppBadges()
+    this.enqueueErrors()
   }
 
   componentDidUpdate(prevProps) {
@@ -80,6 +88,8 @@ class PluginConfig extends Component {
       this.handleTabChange(null, 0)
       this.getAppBadges()
     }
+
+    this.enqueueErrors()
   }
 
   getAppBadges = () => {
@@ -102,16 +112,7 @@ class PluginConfig extends Component {
 
   dismissError = index => {
     const { dispatch, plugin } = this.props
-    dispatch(clearError(plugin.name, index))
-    this.clearPluginErrors()
-  }
-
-  clearPluginErrors = () => {
-    // Clear errors in nano
-    const { plugin, pluginErrors } = this.props
-    if (pluginErrors.length > 0) {
-      plugin.emit('clearPluginErrors')
-    }
+    dispatch(clearError(plugin, index))
   }
 
   appBadgesCount() {
@@ -119,24 +120,48 @@ class PluginConfig extends Component {
     return Object.values(appBadges).reduce((a, b) => a + b, 0)
   }
 
-  renderErrors() {
-    const { pluginErrors } = this.props
-    const renderErrors = []
-    pluginErrors.forEach((error, index) => {
-      const renderError = (
-        <Notification
-          key={index}
-          type="error"
-          message={error}
-          onDismiss={() => {
-            this.dismissError(index)
-          }}
-        />
-      )
-      renderErrors.push(renderError)
-    })
+  enqueueErrors() {
+    const { displayedErrors } = this.state
+    const {
+      pluginErrors,
+      plugin,
+      enqueueSnackbar,
+      dispatch,
+      closeSnackbar
+    } = this.props
 
-    return renderErrors
+    const onClose = (thisPlugin, key) => {
+      dispatch(clearError(thisPlugin, key))
+      delete displayedErrors[key]
+    }
+
+    const action = key => (
+      <Fragment>
+        <Button
+          style={{ color: 'black' }}
+          onClick={() => {
+            closeSnackbar(key)
+            onClose(plugin, key)
+          }}
+        >
+          {'Dismiss'}
+        </Button>
+      </Fragment>
+    )
+
+    dispatch(getPluginErrors(plugin))
+    pluginErrors.forEach(error => {
+      if (displayedErrors[error.key]) return
+      enqueueSnackbar(error.message, {
+        key: error.key,
+        variant: 'error',
+        onClose: (event, reason, key) => {
+          onClose(plugin, key)
+        },
+        action
+      })
+      displayedErrors[error.key] = true
+    })
   }
 
   render() {
@@ -165,7 +190,6 @@ class PluginConfig extends Component {
             {isActivePlugin ? pluginStatus : 'STOPPED'}
           </StyledState>
         </Typography>
-        {this.renderErrors()}
         <StyledAppBar position="static">
           <Tabs
             value={selectedTab}
@@ -244,7 +268,7 @@ function mapStateToProps(state) {
   }
 }
 
-export default connect(mapStateToProps)(PluginConfig)
+export default connect(mapStateToProps)(withSnackbar(PluginConfig))
 
 const StyledAppBar = styled(AppBar)`
   margin: 20px 0;

--- a/src/components/Plugins/PluginConfig/index.js
+++ b/src/components/Plugins/PluginConfig/index.js
@@ -93,10 +93,6 @@ class PluginConfig extends Component {
   handleTabChange = (event, tab) => {
     const { dispatch } = this.props
     dispatch(selectTab(tab))
-    // Clear errors if going to Terminal tab
-    if (tab === 3) {
-      this.clearPluginErrors()
-    }
   }
 
   handlePluginConfigChanged = (key, value) => {

--- a/src/components/Plugins/PluginConfig/index.js
+++ b/src/components/Plugins/PluginConfig/index.js
@@ -135,20 +135,6 @@ class PluginConfig extends Component {
       delete displayedErrors[key]
     }
 
-    const action = key => (
-      <Fragment>
-        <Button
-          style={{ color: 'black' }}
-          onClick={() => {
-            closeSnackbar(key)
-            onClose(plugin, key)
-          }}
-        >
-          {'Dismiss'}
-        </Button>
-      </Fragment>
-    )
-
     dispatch(getPluginErrors(plugin))
     pluginErrors.forEach(error => {
       if (displayedErrors[error.key]) return
@@ -158,7 +144,19 @@ class PluginConfig extends Component {
         onClose: (event, reason, key) => {
           onClose(plugin, key)
         },
-        action
+        action: key => (
+          <Fragment>
+            <Button
+              style={{ color: '#000' }}
+              onClick={() => {
+                closeSnackbar(key)
+                onClose(plugin, key)
+              }}
+            >
+              {'Dismiss'}
+            </Button>
+          </Fragment>
+        )
       })
       displayedErrors[error.key] = true
     })

--- a/src/components/shared/Notification.js
+++ b/src/components/shared/Notification.js
@@ -85,7 +85,7 @@ class Notification extends Component {
     return (
       <Snackbar
         anchorOrigin={{
-          vertical: 'bottom',
+          vertical: 'top',
           horizontal: 'right'
         }}
         open

--- a/src/store/plugin/actions.js
+++ b/src/store/plugin/actions.js
@@ -126,13 +126,35 @@ export const updatePeerCountError = (pluginName, message) => {
 }
 
 export const addPluginError = (pluginName, error) => {
-  return { type: 'PLUGIN:ERROR:ADD', error, payload: { pluginName } }
+  return (dispatch, getState) => {
+    const state = getState()
+    if (state.plugin[pluginName].errors.find(e => e.key === error.key)) {
+      return
+    }
+    dispatch({ type: 'PLUGIN:ERROR:ADD', error, payload: { pluginName } })
+  }
 }
 
-export const clearError = (pluginName, index) => {
+export const getPluginErrors = plugin => {
+  return dispatch => {
+    plugin.getErrors().forEach(error => {
+      dispatch(addPluginError(plugin.name, error))
+    })
+  }
+}
+
+export const clearError = (plugin, key) => {
+  plugin.plugin.dismissError(key)
   return {
-    type: 'PLUGIN:CLEAR_ERROR',
-    payload: { pluginName, index }
+    type: 'PLUGIN:ERROR:CLEAR',
+    payload: { pluginName: plugin.name, key }
+  }
+}
+
+export const clearPluginErrors = plugin => {
+  return {
+    type: 'PLUGIN:ERROR:CLEAR_ALL',
+    payload: { pluginName: plugin.name }
   }
 }
 

--- a/src/store/plugin/actions.js
+++ b/src/store/plugin/actions.js
@@ -155,11 +155,8 @@ export const clearError = (plugin, key) => {
   }
 }
 
-export const clearPluginErrors = plugin => {
-  return {
-    type: 'PLUGIN:ERROR:CLEAR_ALL',
-    payload: { pluginName: plugin.name }
-  }
+export const clearPluginErrors = pluginName => {
+  return { type: 'PLUGIN:ERROR:CLEAR_ALL', payload: { pluginName } }
 }
 
 export const selectPlugin = (pluginName, tab) => {

--- a/src/store/plugin/pluginService.js
+++ b/src/store/plugin/pluginService.js
@@ -59,7 +59,7 @@ class PluginService {
       dispatch(addPluginError(plugin.name, error))
     }
     this.clearPluginErrorsListener = () => {
-      dispatch(clearPluginErrors(plugin))
+      dispatch(clearPluginErrors(plugin.name))
     }
     this.setAppBadgeListener = ({ appId, count }) => {
       dispatch(setAppBadges(plugin, { [appId]: count }))

--- a/src/store/plugin/pluginService.js
+++ b/src/store/plugin/pluginService.js
@@ -1,5 +1,10 @@
 import ClientService from './clientService'
-import { addPluginError, onConnectionUpdate, setAppBadges } from './actions'
+import {
+  addPluginError,
+  onConnectionUpdate,
+  setAppBadges,
+  clearPluginErrors
+} from './actions'
 
 class PluginService {
   async start(plugin, release, flags, config) {
@@ -53,15 +58,20 @@ class PluginService {
     this.pluginErrorListener = error => {
       dispatch(addPluginError(plugin.name, error))
     }
+    this.clearPluginErrorsListener = () => {
+      dispatch(clearPluginErrors(plugin))
+    }
     this.setAppBadgeListener = ({ appId, count }) => {
       dispatch(setAppBadges(plugin, { [appId]: count }))
     }
     plugin.on('pluginError', this.pluginErrorListener)
+    plugin.on('clearPluginErrors', this.clearPluginErrorsListener)
     plugin.on('setAppBadge', this.setAppBadgeListener)
   }
 
   removeListeners(plugin) {
     plugin.removeListener('pluginError', this.pluginErrorListener)
+    plugin.removeListener('clearPluginErrors', this.clearPluginErrorsListener)
     plugin.removeListener('setAppBadge', this.setAppBadgeListener)
     if (plugin.type === 'client') {
       ClientService.clearPeerCountInterval()

--- a/src/store/plugin/reducer.js
+++ b/src/store/plugin/reducer.js
@@ -165,17 +165,26 @@ const plugin = (state = initialState, action) => {
         }
       }
     }
-    case 'PLUGIN:CLEAR_ERROR': {
-      const { pluginName, index } = action.payload
+    case 'PLUGIN:ERROR:CLEAR': {
+      const { pluginName, key } = action.payload
 
       return {
         ...state,
         [pluginName]: {
           ...initialPluginState,
           ...state[pluginName],
-          errors: state[pluginName].errors.filter(
-            (n, nIndex) => nIndex !== index
-          )
+          errors: state[pluginName].errors.filter(error => error.key !== key)
+        }
+      }
+    }
+    case 'PLUGIN:ERROR:CLEAR_ALL': {
+      const { pluginName } = action.payload
+      return {
+        ...state,
+        [pluginName]: {
+          ...initialPluginState,
+          ...state[pluginName],
+          errors: []
         }
       }
     }

--- a/src/store/plugin/reducer.test.js
+++ b/src/store/plugin/reducer.test.js
@@ -150,10 +150,40 @@ describe('the plugin reducer', () => {
     ).toEqual(expectedState)
   })
 
-  it('should handle PLUGIN:CLEAR_ERROR', () => {
+  it('should handle PLUGIN:ERROR:CLEAR', () => {
     const action = {
-      type: 'PLUGIN:CLEAR_ERROR',
-      payload: { pluginName: 'geth', index: 0 }
+      type: 'PLUGIN:ERROR:CLEAR',
+      payload: { pluginName: 'geth', key: 'abc' }
+    }
+    const expectedState = {
+      ...initialState,
+      geth: {
+        ...initialPluginState,
+        errors: [{ key: 'abcd', message: 'boom2' }]
+      }
+    }
+
+    expect(
+      reducer(
+        {
+          ...initialState,
+          geth: {
+            ...initialPluginState,
+            errors: [
+              { key: 'abc', message: 'boom' },
+              { key: 'abcd', message: 'boom2' }
+            ]
+          }
+        },
+        action
+      )
+    ).toEqual(expectedState)
+  })
+
+  it('should handle PLUGIN:ERROR:CLEAR_ALL', () => {
+    const action = {
+      type: 'PLUGIN:ERROR:CLEAR_ALL',
+      payload: { pluginName: 'geth' }
     }
     const expectedState = {
       ...initialState,
@@ -161,7 +191,19 @@ describe('the plugin reducer', () => {
     }
 
     expect(
-      reducer({ ...initialState, geth: initialPluginState }, action)
+      reducer(
+        {
+          ...initialState,
+          geth: {
+            ...initialPluginState,
+            errors: [
+              { key: 'abc', message: 'boom' },
+              { key: 'abcd', message: 'boom2' }
+            ]
+          }
+        },
+        action
+      )
     ).toEqual(expectedState)
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5463,7 +5463,7 @@ hoist-non-react-statics@^3.0.0:
   dependencies:
     react-is "^16.3.2"
 
-hoist-non-react-statics@^3.2.1:
+hoist-non-react-statics@^3.2.1, hoist-non-react-statics@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz#b09178f0122184fb95acf525daaecb4d8f45958b"
   integrity sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==
@@ -8006,6 +8006,16 @@ normalize-url@^3.0.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-3.3.0.tgz#b2e1c4dc4f7c6d57743df733a4f5978d18650559"
 
+notistack@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/notistack/-/notistack-0.9.0.tgz#d195a186f5f25f7316b9e89a91ae3abe1072125e"
+  integrity sha512-3SrMUuJIAn4YtxvHlY6mjYDoQ+NQnozeQUOub5ywc+WEb8n85i/9PO/vqD9lGBXINEgN34B+YEA34oo7yeGYVQ==
+  dependencies:
+    classnames "^2.2.6"
+    hoist-non-react-statics "^3.3.0"
+    prop-types "^15.7.2"
+    react-is "^16.8.6"
+
 npm-bundled@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.0.5.tgz#3c1732b7ba936b3a10325aef616467c0ccbcc979"
@@ -9308,7 +9318,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@^15.5.10, prop-types@^15.5.7:
+prop-types@^15.5.10, prop-types@^15.5.7, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -9590,6 +9600,11 @@ react-is@^16.8.1:
   version "16.8.3"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.3.tgz#4ad8b029c2a718fc0cfc746c8d4e1b7221e5387d"
   integrity sha512-Y4rC1ZJmsxxkkPuMLwvKvlL1Zfpbcu+Bf4ZigkHup3v9EfdYhAlWAaVyA19olXq2o2mGn0w+dFKvk3pVVlYcIA==
+
+react-is@^16.8.6:
+  version "16.9.0"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"
+  integrity sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw==
 
 react-lifecycles-compat@^3.0.0, react-lifecycles-compat@^3.0.2, react-lifecycles-compat@^3.0.4:
   version "3.0.4"


### PR DESCRIPTION
#### What does it do?
Use `notistack` to stack snackbars so they don't overlap

Also uses new `getErrors` and `dismissError(key)` in grid: https://github.com/ethereum/grid/pull/468

Also converts FlagPreview to use notistack (and incorporates https://github.com/ethereum/grid-ui/pull/148)

Closes https://github.com/ethereum/grid/issues/467
Closes https://github.com/ethereum/grid/issues/466

---

<img width="1212" alt="Screen Shot 2019-09-09 at 5 14 27 PM" src="https://user-images.githubusercontent.com/22116/64574688-4f591680-d325-11e9-9ee4-2ecdf7356c5e.png">

<img width="1098" alt="Screen Shot 2019-09-09 at 5 09 14 PM" src="https://user-images.githubusercontent.com/22116/64574658-36506580-d325-11e9-8fe5-a33d5dc8fa9f.png">
