### PR TITLE
fix: only show custom flag warning once

### DIFF
--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/FlagPreview.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/FlagPreview.js
@@ -5,7 +5,10 @@ import TextField from '@material-ui/core/TextField'
 import FormGroup from '@material-ui/core/FormGroup'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import Checkbox from '@material-ui/core/Checkbox'
-import { setCustomFlags } from '../../../../store/plugin/actions'
+import {
+  dismissFlagWarning,
+  setCustomFlags
+} from '../../../../store/plugin/actions'
 import Notification from '../../../shared/Notification'
 
 class FlagPreview extends Component {
@@ -15,10 +18,9 @@ class FlagPreview extends Component {
     flags: PropTypes.array,
     isEditingFlags: PropTypes.bool,
     toggleEditGeneratedFlags: PropTypes.func,
-    dispatch: PropTypes.func
+    dispatch: PropTypes.func,
+    showWarning: PropTypes.bool
   }
-
-  state = { showWarning: true }
 
   toggleEdit = event => {
     const { toggleEditGeneratedFlags } = this.props
@@ -32,9 +34,13 @@ class FlagPreview extends Component {
     dispatch(setCustomFlags(pluginName, flags))
   }
 
+  dismissFlagWarning = () => {
+    const { dispatch } = this.props
+    dispatch(dismissFlagWarning())
+  }
+
   render() {
-    const { flags, isEditingFlags, isPluginRunning } = this.props
-    const { showWarning } = this.state
+    const { flags, isEditingFlags, isPluginRunning, showWarning } = this.props
 
     return (
       <React.Fragment>
@@ -65,7 +71,7 @@ class FlagPreview extends Component {
           <Notification
             type="warning"
             message="Use caution! Don't take flags from strangers."
-            onDismiss={() => this.setState({ showWarning: false })}
+            onDismiss={this.dismissFlagWarning}
           />
         )}
       </React.Fragment>
@@ -73,8 +79,10 @@ class FlagPreview extends Component {
   }
 }
 
-function mapStateToProps() {
-  return {}
+function mapStateToProps(state) {
+  return {
+    showWarning: state.plugin.showCustomFlagWarning
+  }
 }
 
 export default connect(mapStateToProps)(FlagPreview)

--- a/src/store/plugin/actions.js
+++ b/src/store/plugin/actions.js
@@ -73,6 +73,10 @@ export const initPlugin = plugin => {
   }
 }
 
+export const dismissFlagWarning = () => {
+  return { type: 'PLUGIN:DISMISS_FLAG_WARNING' }
+}
+
 export const newBlock = (pluginName, blockNumber, timestamp) => {
   return {
     type: 'PLUGIN:UPDATE_NEW_BLOCK',

--- a/src/store/plugin/reducer.js
+++ b/src/store/plugin/reducer.js
@@ -1,6 +1,7 @@
 export const initialState = {
   selected: 'geth',
-  selectedTab: 0
+  selectedTab: 0,
+  showCustomFlagWarning: true
   // Plugins dynamically populate within this object, e.g.
   // geth: { config: {}, release: {}, ... },
   // parity: { config: {}, release: {}, ... },
@@ -110,6 +111,9 @@ const plugin = (state = initialState, action) => {
           flags
         }
       }
+    }
+    case 'PLUGIN:DISMISS_FLAG_WARNING': {
+      return { ...state, showCustomFlagWarning: false }
     }
     case 'PLUGIN:START': {
       const { pluginName, version } = action.payload

--- a/src/store/plugin/reducer.test.js
+++ b/src/store/plugin/reducer.test.js
@@ -41,6 +41,13 @@ describe('the plugin reducer', () => {
     expect(reducer(initialState, action)).toEqual(expectedState)
   })
 
+  it('should handle PLUGIN:DISMISS_FLAG_WARNING', () => {
+    const action = { type: 'PLUGIN:DISMISS_FLAG_WARNING' }
+    const expectedState = { ...initialState, showCustomFlagWarning: false }
+
+    expect(reducer(initialState, action)).toEqual(expectedState)
+  })
+
   it('should handle PLUGIN:SELECT_TAB', () => {
     const action = {
       type: 'PLUGIN:SELECT_TAB',


### PR DESCRIPTION
#### What does it do?
Limit the "don't take flags from strangers" notification to once per run of Grid.
#### Does it close any issues?
Closes https://github.com/ethereum/grid/issues/466