### PR TITLE
fix: remove terminal styling

### DIFF
--- a/src/components/Plugins/PluginView/index.js
+++ b/src/components/Plugins/PluginView/index.js
@@ -11,22 +11,8 @@ import moment from 'moment'
 require('codemirror/mode/javascript/javascript')
 
 const styles = () => ({
-  terminalWrapper: {
-    background: '#111',
-    color: '#eee',
-    fontFamily:
-      'Lucida Console, Lucida Sans Typewriter, monaco, Bitstream Vera Sans Mono, monospace',
-    fontSize: '11px',
-    padding: 10,
-
-    // Fluid width and height with support to scrolling
-    width: 'calc(100vw - 310px)',
-    height: 'calc(100vh - 274px)',
-
-    // Scroll config
-    overflowX: 'auto',
-    overflowY: 'scroll',
-    whiteSpace: 'nowrap'
+  pluginCode: {
+    width: 'calc(100vw - 310px)'
   }
 })
 
@@ -167,7 +153,7 @@ class PluginView extends Component {
         )}
         <h3 style={{ color: 'grey' }}>Plugin Code</h3>
         <CodeMirror
-          className={classes.terminalWrapper}
+          className={classes.pluginCode}
           value={plugin.source}
           options={{
             mode: 'javascript',


### PR DESCRIPTION
#### What does it do?
Merging wiped out some styling fixes on plugin code. See 'before' screenshot. Fixes https://github.com/ethereum/grid/issues/475.
#### Relevant screenshots?
before: 
<img width="831" alt="Screen Shot 2019-09-16 at 2 19 06 PM" src="https://user-images.githubusercontent.com/3621728/64991091-6c926580-d88e-11e9-961d-d415a3112509.png">
after:
<img width="866" alt="Screen Shot 2019-09-16 at 2 26 29 PM" src="https://user-images.githubusercontent.com/3621728/64991111-74eaa080-d88e-11e9-90c3-9ec3db7de5f5.png">
