### PR TITLE
feat: restore default settings

### DIFF
--- a/src/components/Plugins/NodeInfo/NodeInfoDot.js
+++ b/src/components/Plugins/NodeInfo/NodeInfoDot.js
@@ -54,7 +54,6 @@ class NodeInfoDot extends Component {
     const { network } = config
 
     const pulseColor = network === 'main' ? 'green' : 'blue'
-    console.log('∆∆∆ pulse!', pulseColor)
 
     this.setState({ pulseColor }, () => {
       setTimeout(() => {

--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/FlagPreview.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/FlagPreview.js
@@ -8,6 +8,7 @@ import Button from '@material-ui/core/Button'
 import FormGroup from '@material-ui/core/FormGroup'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import Checkbox from '@material-ui/core/Checkbox'
+import Grid from '@material-ui/core/Grid'
 import {
   dismissFlagWarning,
   restoreDefaultSettings,
@@ -156,27 +157,32 @@ class FlagPreview extends Component {
             disabled={isPluginRunning || !isEditingFlags}
             fullWidth
           />
-          <FormControlLabel
-            control={
-              <Checkbox
-                color="primary"
-                checked={isEditingFlags}
-                onChange={this.toggleEdit}
-                disabled={isPluginRunning}
-                style={{ marginLeft: 10 }}
-              />
-            }
-            label="Use custom flags"
-          />
         </FormGroup>
-
-        <Button
-          style={{ float: 'right' }}
-          color="primary"
-          onClick={this.handleRestoreDefaultSettings}
-        >
-          Restore Defaults
-        </Button>
+        <Grid container style={{ marginTop: 5, marginBottom: 15 }}>
+          <Grid item xs={6}>
+            <FormControlLabel
+              control={
+                <Checkbox
+                  color="primary"
+                  checked={isEditingFlags}
+                  onChange={this.toggleEdit}
+                  disabled={isPluginRunning}
+                  style={{ marginLeft: 10 }}
+                />
+              }
+              label="Use custom flags"
+            />
+          </Grid>
+          <Grid item xs={6} style={{ textAlign: 'right' }}>
+            <Button
+              style={{ marginTop: 5 }}
+              color="primary"
+              onClick={this.handleRestoreDefaultSettings}
+            >
+              Restore Defaults
+            </Button>
+          </Grid>
+        </Grid>
       </React.Fragment>
     )
   }

--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/FlagPreview.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/FlagPreview.js
@@ -54,12 +54,16 @@ class FlagPreview extends Component {
     // e.g. restore defaults, update local state
     const newFlags = flags.join(' ')
     if (localFlags !== newFlags && !isEditingFlags) {
-      this.setState({ flags: newFlags })
+      this.updateFlags(newFlags)
     }
   }
 
   componentWillUnmount() {
     this.updateRedux.cancel()
+  }
+
+  updateFlags = flags => {
+    this.setState({ flags })
   }
 
   handleShowWarning = () => {

--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/FlagPreview.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/FlagPreview.js
@@ -111,9 +111,28 @@ class FlagPreview extends Component {
   }
 
   handleRestoreDefaultSettings = () => {
-    const { dispatch, plugin } = this.props
+    const { dispatch, plugin, closeSnackbar, enqueueSnackbar } = this.props
     this.setState({ flags: this.defaultFlags }, () => {
       dispatch(restoreDefaultSettings(plugin))
+      enqueueSnackbar('Default settings restored!', {
+        variant: 'success',
+        onClose: () => {
+          this.dismissFlagWarning()
+        },
+        action: key => (
+          <Fragment>
+            <Button
+              style={{ color: '#000' }}
+              onClick={() => {
+                closeSnackbar(key)
+                this.dismissFlagWarning()
+              }}
+            >
+              {'Dismiss'}
+            </Button>
+          </Fragment>
+        )
+      })
     })
   }
 

--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/FlagPreview.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/FlagPreview.js
@@ -26,32 +26,47 @@ class FlagPreview extends Component {
     closeSnackbar: PropTypes.func
   }
 
+  constructor(props) {
+    super(props)
+
+    // NOTE: for performance, form fields are populated by local state.
+    // Redux state doesn't need to update on every keystroke.
+    this.updateRedux = debounce(this.updateRedux, 500)
+    this.state = {
+      flags: props.flags.join(' '),
+      warningHasBeenShown: false
+    }
+  }
+
   componentDidUpdate = () => {
+    const { warningHasBeenShown } = this.state
     const {
       isEditingFlags,
       showWarning,
       enqueueSnackbar,
       closeSnackbar
     } = this.props
-    if (isEditingFlags && showWarning) {
-      enqueueSnackbar("Use caution! Don't take flags from strangers.", {
-        variant: 'warning',
-        onClose: () => {
-          this.dismissFlagWarning()
-        },
-        action: key => (
-          <Fragment>
-            <Button
-              style={{ color: '#000' }}
-              onClick={() => {
-                closeSnackbar(key)
-                this.dismissFlagWarning()
-              }}
-            >
-              {'Dismiss'}
-            </Button>
-          </Fragment>
-        )
+    if (isEditingFlags && showWarning && !warningHasBeenShown) {
+      this.setState({ warningHasBeenShown: true }, () => {
+        enqueueSnackbar("Use caution! Don't take flags from strangers.", {
+          variant: 'warning',
+          onClose: () => {
+            this.dismissFlagWarning()
+          },
+          action: key => (
+            <Fragment>
+              <Button
+                style={{ color: '#000' }}
+                onClick={() => {
+                  closeSnackbar(key)
+                  this.dismissFlagWarning()
+                }}
+              >
+                {'Dismiss'}
+              </Button>
+            </Fragment>
+          )
+        })
       })
     }
   }

--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/FlagPreview.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/FlagPreview.js
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from 'react'
 import { connect } from 'react-redux'
+import debounce from 'lodash/debounce'
 import { withSnackbar } from 'notistack'
 import PropTypes from 'prop-types'
 import TextField from '@material-ui/core/TextField'
@@ -61,10 +62,16 @@ class FlagPreview extends Component {
   }
 
   handleChange = event => {
-    const { dispatch, plugin } = this.props
-    const flags = event.target.value.split(' ')
+    const { plugin } = this.props
     const pluginName = plugin[plugin.selected].name
-    dispatch(setCustomFlags(pluginName, flags))
+    const flags = event.target.value
+    this.setState({ flags })
+    this.updateRedux(pluginName, flags)
+  }
+
+  updateRedux = (pluginName, flags) => {
+    const { dispatch } = this.props
+    dispatch(setCustomFlags(pluginName, flags.split(' ')))
   }
 
   dismissFlagWarning = () => {
@@ -73,7 +80,8 @@ class FlagPreview extends Component {
   }
 
   render() {
-    const { flags, isEditingFlags, isPluginRunning } = this.props
+    const { isEditingFlags, isPluginRunning } = this.props
+    const { flags } = this.state
 
     return (
       <React.Fragment>
@@ -82,7 +90,7 @@ class FlagPreview extends Component {
             label="Generated Flags"
             variant="outlined"
             multiline
-            value={flags.join(' ')}
+            value={flags}
             onChange={this.handleChange}
             disabled={isPluginRunning || !isEditingFlags}
             fullWidth

--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/FormItem.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/FormItem.js
@@ -36,12 +36,16 @@ class DynamicConfigFormItem extends Component {
   componentDidUpdate(prevProps) {
     const { itemValue } = this.props
     if (prevProps.itemValue !== itemValue) {
-      this.setState({ fieldValue: itemValue })
+      this.updateField(itemValue)
     }
   }
 
   componentWillUnmount() {
     this.updateRedux.cancel()
+  }
+
+  updateField = fieldValue => {
+    this.setState({ fieldValue })
   }
 
   showOpenDialog = key => async event => {

--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/FormItem.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/FormItem.js
@@ -14,11 +14,11 @@ class DynamicConfigFormItem extends Component {
     itemKey: PropTypes.string,
     itemValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     item: PropTypes.object,
-    plugin: PropTypes.object,
+    pluginState: PropTypes.object,
     pluginName: PropTypes.string,
     isPluginRunning: PropTypes.bool,
     handlePluginConfigChanged: PropTypes.func,
-    editGeneratedFlags: PropTypes.bool
+    isEditingFlags: PropTypes.bool
   }
 
   constructor(props) {
@@ -41,14 +41,12 @@ class DynamicConfigFormItem extends Component {
     const { showOpenDialog } = GridAPI
     // If we don't have showOpenDialog from Grid,
     // return true to continue with native file dialog
-    if (!showOpenDialog) {
-      return true
-    }
+    if (!showOpenDialog) return true
     // Continue with Grid.showOpenDialog()
     event.preventDefault()
-    const { plugin, pluginName, item } = this.props
+    const { pluginState, pluginName, item } = this.props
     const { type } = item
-    const defaultPath = plugin[pluginName].config[key]
+    const defaultPath = pluginState[pluginName].config[key]
     const pathType = type.replace('_multiple', '')
     const selectMultiple = type.includes('multiple')
     const path = await showOpenDialog(pathType, selectMultiple, defaultPath)
@@ -68,9 +66,9 @@ class DynamicConfigFormItem extends Component {
 
   render() {
     const { fieldValue } = this.state
-    const { itemKey, item, isPluginRunning, editGeneratedFlags } = this.props
+    const { itemKey, item, isPluginRunning, isEditingFlags } = this.props
     const label = item.label || itemKey
-    const disabled = isPluginRunning || editGeneratedFlags
+    const disabled = isPluginRunning || isEditingFlags
     let { type } = item
     if (!type) type = item.options ? 'select' : 'text'
     let options
@@ -86,7 +84,7 @@ class DynamicConfigFormItem extends Component {
             optionLabel = el
             optionValue = el
           } else if (typeof el === 'object') {
-            // eg: [{label: 'Ropsten test network', value: 'Ropsten', flag: '--testnet'}]
+            // eg: [{ label: 'Ropsten (testnet)', value: 'Ropsten', flag: '--testnet' }]
             optionLabel = el.label
             optionValue = el.value
           } else {
@@ -100,7 +98,7 @@ class DynamicConfigFormItem extends Component {
           <div data-test-id={`input-select-${item.id}`}>
             <Select
               name={label}
-              defaultValue={fieldValue}
+              value={fieldValue}
               options={options}
               disabled={disabled}
               onChange={value => this.handleChange(itemKey, value)}
@@ -177,6 +175,7 @@ function mapStateToProps(state, ownProps) {
   const selectedPlugin = state.plugin.selected
 
   return {
+    pluginState: state.plugin,
     itemValue: state.plugin[selectedPlugin].config[ownProps.itemKey]
   }
 }

--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/FormItem.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/FormItem.js
@@ -33,6 +33,13 @@ class DynamicConfigFormItem extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    const { itemValue } = this.props
+    if (prevProps.itemValue !== itemValue) {
+      this.setState({ fieldValue: itemValue })
+    }
+  }
+
   componentWillUnmount() {
     this.updateRedux.cancel()
   }

--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/index.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/index.js
@@ -86,8 +86,8 @@ class DynamicConfigForm extends Component {
         >
           {formItems}
         </Grid>
-        <hr />
-        <div style={{ marginTop: 25 }}>
+        <hr style={{ opacity: 0.7 }} />
+        <div style={{ marginTop: 30 }}>
           <FlagPreview
             flags={flags}
             config={config}

--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/index.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/index.js
@@ -2,14 +2,9 @@ import React, { Component } from 'react'
 import { connect } from 'react-redux'
 import PropTypes from 'prop-types'
 import Grid from '@material-ui/core/Grid'
-import Button from '../../../shared/Button'
 import FormItem from './FormItem'
 import FlagPreview from './FlagPreview'
-import {
-  getGeneratedFlags,
-  restoreDefaultSettings,
-  setFlags
-} from '../../../../store/plugin/actions'
+import { getGeneratedFlags, setFlags } from '../../../../store/plugin/actions'
 
 class DynamicConfigForm extends Component {
   static propTypes = {
@@ -30,10 +25,8 @@ class DynamicConfigForm extends Component {
     )
     const { config, flags } = pluginState[pluginState.selected]
     const generatedFlags = getGeneratedFlags(preloadPlugin, config)
-    const flagsIsCustom = !flags.every(f => generatedFlags.includes(f))
-    this.state = {
-      editGeneratedFlags: flagsIsCustom
-    }
+    const isEditingFlags = !flags.every(f => generatedFlags.includes(f))
+    this.state = { isEditingFlags }
   }
 
   toggleEditGeneratedFlags = checked => {
@@ -42,7 +35,7 @@ class DynamicConfigForm extends Component {
     const preloadPlugin = window.Grid.PluginHost.getPluginByName(
       pluginState.selected
     )
-    this.setState({ editGeneratedFlags: checked })
+    this.setState({ isEditingFlags: checked })
     if (!checked) {
       dispatch(setFlags(preloadPlugin, config))
     }
@@ -57,36 +50,25 @@ class DynamicConfigForm extends Component {
   }
 
   wrapFormItem = item => {
-    const {
-      pluginState,
-      plugin,
-      isPluginRunning,
-      handlePluginConfigChanged
-    } = this.props
-    const { editGeneratedFlags } = this.state
+    const { plugin, isPluginRunning, handlePluginConfigChanged } = this.props
+    const { isEditingFlags } = this.state
     return (
       <FormItem
         key={item.id}
         itemKey={item.id}
         item={item}
-        plugin={pluginState}
         pluginName={plugin.name}
         isPluginRunning={isPluginRunning}
         handlePluginConfigChanged={handlePluginConfigChanged}
-        editGeneratedFlags={editGeneratedFlags}
+        isEditingFlags={isEditingFlags}
       />
     )
   }
 
-  handleRestoreDefaultSettings = () => {
-    const { dispatch, plugin } = this.props
-    dispatch(restoreDefaultSettings(plugin))
-  }
-
   render() {
-    const { settings, pluginState, isPluginRunning } = this.props
-    const { editGeneratedFlags } = this.state
-    const { flags } = pluginState[pluginState.selected]
+    const { settings, plugin, pluginState, isPluginRunning } = this.props
+    const { isEditingFlags } = this.state
+    const { config, flags } = pluginState[pluginState.selected]
 
     if (!settings) return <h4>No configuration settings found</h4>
 
@@ -108,18 +90,13 @@ class DynamicConfigForm extends Component {
         <div style={{ marginTop: 25 }}>
           <FlagPreview
             flags={flags}
-            plugin={pluginState}
-            isEditingFlags={editGeneratedFlags}
+            config={config}
+            plugin={plugin}
+            isEditingFlags={isEditingFlags}
             toggleEditGeneratedFlags={this.toggleEditGeneratedFlags}
             isPluginRunning={isPluginRunning}
           />
         </div>
-        <Button
-          style={{ float: 'right' }}
-          onClick={this.handleRestoreDefaultSettings}
-        >
-          Restore Defaults
-        </Button>
       </div>
     )
   }

--- a/src/components/Plugins/PluginConfig/index.js
+++ b/src/components/Plugins/PluginConfig/index.js
@@ -290,7 +290,7 @@ class PluginConfig extends Component {
           <TabContainer>
             <ErrorBoundary>
               <DynamicConfigForm
-                pluginName={plugin.name}
+                plugin={plugin}
                 settings={getPluginSettingsConfig(plugin)}
                 handlePluginConfigChanged={this.handlePluginConfigChanged}
                 isPluginRunning={isRunning}

--- a/src/components/Plugins/index.js
+++ b/src/components/Plugins/index.js
@@ -71,13 +71,13 @@ class PluginsTab extends Component {
     const { pluginState, dispatch } = this.props
     const { plugins } = this.state
 
-    const plugin = plugins.filter(c => c.name === pluginState.selected)[0]
+    const activePlugin = plugins.filter(p => p.name === pluginState.selected)[0]
 
     const { config } = pluginState[pluginState.selected]
     const newConfig = { ...config }
     newConfig[key] = value
 
-    dispatch(setConfig(plugin, newConfig))
+    dispatch(setConfig(activePlugin, newConfig))
   }
 
   handleReleaseSelect = release => {

--- a/src/components/shared/Select.js
+++ b/src/components/shared/Select.js
@@ -26,11 +26,7 @@ export default class Select extends Component {
 
   constructor(props) {
     super(props)
-
-    this.state = {
-      value: props.value || '',
-      labelWidth: 0
-    }
+    this.state = { labelWidth: 0 }
   }
 
   componentDidMount() {
@@ -40,17 +36,9 @@ export default class Select extends Component {
     })
   }
 
-  handleChange = e => {
-    const { onChange } = this.props
-
-    this.setState({ value: e.target.value }, () => {
-      if (onChange) onChange(e.target.value)
-    })
-  }
-
   render() {
-    const { name, id, options, disabled } = this.props
-    const { labelWidth, value } = this.state
+    const { name, id, onChange, options, disabled, value } = this.props
+    const { labelWidth } = this.state
 
     const opts = options.map(option => (
       <MenuItem key={option.value} value={option.value}>
@@ -74,7 +62,7 @@ export default class Select extends Component {
         </InputLabel>
         <MuiSelect
           value={value}
-          onChange={this.handleChange}
+          onChange={e => onChange(e.target.value)}
           input={<OutlinedInput labelWidth={labelWidth} name={name} id={id} />}
         >
           {opts}

--- a/src/components/shared/Select.js
+++ b/src/components/shared/Select.js
@@ -13,7 +13,7 @@ export default class Select extends Component {
   static propTypes = {
     id: PropTypes.string,
     name: PropTypes.string,
-    defaultValue: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+    value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     onChange: PropTypes.func,
     options: PropTypes.array,
     disabled: PropTypes.bool
@@ -28,7 +28,7 @@ export default class Select extends Component {
     super(props)
 
     this.state = {
-      value: props.defaultValue || '',
+      value: props.value || '',
       labelWidth: 0
     }
   }
@@ -44,9 +44,7 @@ export default class Select extends Component {
     const { onChange } = this.props
 
     this.setState({ value: e.target.value }, () => {
-      if (onChange) {
-        onChange(e.target.value)
-      }
+      if (onChange) onChange(e.target.value)
     })
   }
 

--- a/src/lib/utils.js
+++ b/src/lib/utils.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Grid } from '../API'
+import { generateFlags } from './flags'
 
 // calling styled(without('unneededProp')(TheComponent))
 // helps satisfy error of extra StyledComponents props passing into children
@@ -51,6 +52,18 @@ export const getDefaultSetting = (plugin, id) => {
   } catch (e) {
     return ''
   }
+}
+
+export const getDefaultFlags = (plugin, config) => {
+  const pluginDefaults = {}
+  const pluginSettings = getPluginSettingsConfig(plugin)
+  pluginSettings.forEach(setting => {
+    if ('default' in setting) {
+      pluginDefaults[setting.id] = setting.default
+    }
+  })
+
+  return generateFlags(pluginDefaults, pluginSettings)
 }
 
 export const getSettingsIds = plugin => {

--- a/src/store/plugin/actions.js
+++ b/src/store/plugin/actions.js
@@ -12,19 +12,21 @@ export const onConnectionUpdate = (pluginName, status) => {
   return { type: 'PLUGIN:STATUS_UPDATE', payload: { pluginName, status } }
 }
 
-const buildPluginDefaults = plugin => {
+const buildPluginSettings = (plugin, restoreDefaults = false) => {
   const pluginDefaults = {}
-  const settingsIds = getSettingsIds(plugin)
 
-  // Handle rehydration: if config.json has settings already, use them.
-  const persistedSettings = getPersistedPluginSettings(plugin.name)
-  if (settingsIds.length && persistedSettings) {
-    if (Object.keys(persistedSettings).length) {
-      settingsIds.forEach(id => {
-        pluginDefaults[id] =
-          persistedSettings[id] || getDefaultSetting(plugin, id)
-      })
-      return pluginDefaults
+  if (!restoreDefaults) {
+    const settingsIds = getSettingsIds(plugin)
+    // Handle rehydration: if config.json has settings already, use them.
+    const persistedSettings = getPersistedPluginSettings(plugin.name)
+    if (settingsIds.length && persistedSettings) {
+      if (Object.keys(persistedSettings).length) {
+        settingsIds.forEach(id => {
+          pluginDefaults[id] =
+            persistedSettings[id] || getDefaultSetting(plugin, id)
+        })
+        return pluginDefaults
+      }
     }
   }
 
@@ -46,7 +48,7 @@ export const getGeneratedFlags = (plugin, config) => {
 
 export const initPlugin = plugin => {
   return dispatch => {
-    const config = buildPluginDefaults(plugin)
+    const config = buildPluginSettings(plugin)
     const pluginData = plugin.plugin.config
     const flags =
       getPersistedFlags(plugin.name) || getGeneratedFlags(plugin, config)
@@ -193,6 +195,13 @@ export const setConfig = (plugin, config) => {
       payload: { pluginName, config }
     })
     dispatch(setFlags(plugin, config))
+  }
+}
+
+export const restoreDefaultSettings = plugin => {
+  return dispatch => {
+    const config = buildPluginSettings(plugin, true)
+    dispatch(setConfig(plugin, config))
   }
 }
 

--- a/src/store/plugin/actions.js
+++ b/src/store/plugin/actions.js
@@ -42,8 +42,7 @@ const buildPluginSettings = (plugin, restoreDefaults = false) => {
 
 export const getGeneratedFlags = (plugin, config) => {
   const settings = getPluginSettingsConfig(plugin)
-  const flags = generateFlags(config, settings)
-  return flags
+  return generateFlags(config, settings)
 }
 
 export const initPlugin = plugin => {


### PR DESCRIPTION
#### What does it do?
- Adds a `Restore Defaults` button to the bottom of the settings page.
- Fixes multiple custom flags warnings
- Additional cleanup along the way
#### Any helpful background information?
- Did some pruning along the way. The logic around settings and flag generation is still difficult to parse and kind of a mess. 
- `Select` component was buggy, not updating on new `value` prop updates
- Debounced the flag input field for performance. I think all text input fields now immediately update local state and debounce redux cycles.
#### Relevant screenshots?
https://imgur.com/jwxbVLI
#### Does it close any issues?
Closes https://github.com/ethereum/grid/issues/485
Closes https://github.com/ethereum/grid/issues/478