### PR TITLE
fix: hide undefined bin values

### DIFF
--- a/src/components/Plugins/PluginConfig/VersionList/VersionListItem.js
+++ b/src/components/Plugins/PluginConfig/VersionList/VersionListItem.js
@@ -41,7 +41,17 @@ export default class VersionListItem extends Component {
     const { plugin } = this.props
     const { displayName } = plugin
     const { platform, arch, displayVersion } = release
-    return `${displayName} ${displayVersion} - ${platform} (${arch})`
+
+    let metadata
+    if (!platform) {
+      metadata = ''
+    } else if (!arch) {
+      metadata = ` - ${platform}`
+    } else {
+      metadata = ` - ${platform} (${arch})`
+    }
+
+    return `${displayName} ${displayVersion}${metadata}`
   }
 
   downloadRelease = release => {


### PR DESCRIPTION
#### What does it do?
Handles undefined platform and arch values when displaying bin versions