### PR TITLE
chore: metadata rename

### DIFF
--- a/src/components/Plugins/Metadata/index.js
+++ b/src/components/Plugins/Metadata/index.js
@@ -16,7 +16,7 @@ const styles = () => ({
   }
 })
 
-class PluginView extends Component {
+class Metadata extends Component {
   static propTypes = {
     classes: PropTypes.object,
     plugin: PropTypes.object.isRequired
@@ -169,4 +169,4 @@ class PluginView extends Component {
   }
 }
 
-export default withStyles(styles)(PluginView)
+export default withStyles(styles)(Metadata)

--- a/src/components/Plugins/Metadata/index.js
+++ b/src/components/Plugins/Metadata/index.js
@@ -39,10 +39,11 @@ class Metadata extends Component {
       // remote,
       verificationResult
     } = metadata
-    const { signers, isTrusted, isValid } = verificationResult
+    const { signers, /* isTrusted, */ isValid } = verificationResult
 
     return (
       <Fragment>
+        {/*
         <Grid item xs={4}>
           <TextField
             disabled
@@ -53,6 +54,7 @@ class Metadata extends Component {
             margin="normal"
           />
         </Grid>
+        */}
         <Grid item xs={4}>
           <TextField
             disabled
@@ -93,6 +95,7 @@ class Metadata extends Component {
             margin="normal"
           />
         </Grid>
+        {/*
         <Grid item xs={4}>
           <TextField
             disabled
@@ -103,6 +106,7 @@ class Metadata extends Component {
             margin="normal"
           />
         </Grid>
+        */}
         <Grid item xs={4}>
           <TextField
             disabled

--- a/src/components/Plugins/PluginConfig/index.js
+++ b/src/components/Plugins/PluginConfig/index.js
@@ -14,7 +14,7 @@ import DynamicConfigForm from './DynamicConfigForm'
 import AboutPlugin from './AboutPlugin'
 import Terminal from '../Terminal'
 import NodeInfo from '../NodeInfo'
-import PluginView from '../PluginView'
+import Metadata from '../Metadata'
 import {
   clearError,
   selectTab,
@@ -304,7 +304,7 @@ class PluginConfig extends Component {
         </TabContainer>
         {selectedTab === 4 && (
           <TabContainer>
-            <PluginView plugin={plugin} />
+            <Metadata plugin={plugin} />
           </TabContainer>
         )}
       </Fragment>


### PR DESCRIPTION
#### What does it do?
- renames PluginView -> Metadata
- hides author-related fields until logic implemented
#### Any helpful background information?
It's a bad look to display our maintained plugins as untrusted.