### PR TITLE
feat: ignoreIfEmpty flag setting

### DIFF
--- a/src/components/Plugins/PluginConfig/DynamicConfigForm/FormItem.js
+++ b/src/components/Plugins/PluginConfig/DynamicConfigForm/FormItem.js
@@ -128,6 +128,9 @@ class DynamicConfigFormItem extends Component {
               label={item.label}
               value={fieldValue || ''}
               onChange={event => this.handleChange(itemKey, event.target.value)}
+              placeholder={
+                item.ignoreIfEmpty ? '(Leave empty to use default)' : ''
+              }
               disabled={disabled}
               InputProps={{
                 endAdornment: (

--- a/src/components/Plugins/PluginConfig/index.js
+++ b/src/components/Plugins/PluginConfig/index.js
@@ -128,7 +128,11 @@ class PluginConfig extends Component {
     }
     if (type === 'download-progress') {
       const { downloadProgress } = event
-      this.setState({ setupState: `Downloading ${downloadProgress}%` })
+      if (downloadProgress < 100) {
+        this.setState({ setupState: `Downloading ${downloadProgress}%` })
+      } else {
+        this.setState({ setupState: null })
+      }
     }
     if (type === 'extraction-progress') {
       const { extractionProgress } = event

--- a/src/lib/flags.js
+++ b/src/lib/flags.js
@@ -1,11 +1,15 @@
 /**
- * This method preserves spaces contained in the value.
+ * This method:
+ * 1) returns nothing if ignoreIfEmpty && value === ''
+ * 2) preserves spaces contained in the value.
  * input: "--ipc '%s'", "/path with spaces"
  * output: ["--ipc", "/path with spaces"]
  */
-const parseFlag = (pattern, value) => {
-  let result = pattern.split(' ').map(e => e.replace(/%s/, value))
-
+const parseFlag = (pattern, value, ignoreIfEmpty) => {
+  if (ignoreIfEmpty && !value) {
+    return ''
+  }
+  const result = pattern.split(' ').map(e => e.replace(/%s/, value))
   return result
 }
 
@@ -40,7 +44,11 @@ export const generateFlags = (userConfig, nodeSettings) => {
       throw new Error(`Config entry "${entry}" must have the "flag" key`)
     }
 
-    const parsedFlag = parseFlag(pattern, userConfig[entry])
+    const parsedFlag = parseFlag(
+      pattern,
+      userConfig[entry],
+      configEntry.ignoreIfEmpty
+    )
     flags = flags.concat(parsedFlag)
   })
 

--- a/src/test/settings.test.js
+++ b/src/test/settings.test.js
@@ -210,6 +210,23 @@ describe('generateFlags', () => {
     expect(flags).toEqual([])
   })
 
+  it('should output flag if value is a space and ignoreIfEmpty is true', () => {
+    const input = { dataDir: ' ' }
+    const settings = [
+      {
+        id: 'dataDir',
+        default: '',
+        label: 'Data Directory',
+        flag: '--datadir %s',
+        type: 'directory',
+        ignoreIfEmpty: true
+      }
+    ]
+
+    const flags = generateFlags(input, settings)
+    expect(flags).toEqual(['--datadir', ' '])
+  })
+
   it('should not ignore empty setting if ignoreIfEmpty is undefined', () => {
     const input = { dataDir: '' }
     const settings = [

--- a/src/test/settings.test.js
+++ b/src/test/settings.test.js
@@ -192,6 +192,39 @@ describe('generateFlags', () => {
     const flags = generateFlags(input, settings)
     expect(flags).toEqual(['--ipc', '/path/with spaces.ipc'])
   })
+
+  it('should ignore empty setting if ignoreIfEmpty is true', () => {
+    const input = { dataDir: '' }
+    const settings = [
+      {
+        id: 'dataDir',
+        default: '',
+        label: 'Data Directory',
+        flag: '--datadir %s',
+        type: 'directory',
+        ignoreIfEmpty: true
+      }
+    ]
+
+    const flags = generateFlags(input, settings)
+    expect(flags).toEqual([])
+  })
+
+  it('should not ignore empty setting if ignoreIfEmpty is undefined', () => {
+    const input = { dataDir: '' }
+    const settings = [
+      {
+        id: 'dataDir',
+        default: '',
+        label: 'Data Directory',
+        flag: '--datadir %s',
+        type: 'directory'
+      }
+    ]
+
+    const flags = generateFlags(input, settings)
+    expect(flags).toEqual(['--datadir'])
+  })
 })
 
 describe('generateFlags error handling', () => {


### PR DESCRIPTION
#### What does it do? Does it close any issues?
Introduces property `ignoreIfEmpty` to flag settings.

See https://github.com/ethereum/grid/pull/518

Closes one of the issues in https://github.com/ethereum/grid/issues/512

Pairs with https://github.com/ethereum/grid/pull/518