### PR TITLE
fix: disable switch on initial toggle

### DIFF
--- a/src/components/Plugins/PluginsNavListItem.js
+++ b/src/components/Plugins/PluginsNavListItem.js
@@ -37,15 +37,34 @@ class PluginsNavListItem extends Component {
     appBadges: PropTypes.object
   }
 
+  state = {
+    isToggled: false
+  }
+
   badgeContent = () => {
     const { appBadges } = this.props
     return Object.values(appBadges).reduce((a, b) => a + b, 0)
   }
 
+  toggleOff = plugin => newState => {
+    if (['started', 'connected', 'stopped'].includes(newState)) {
+      this.setState({ isToggled: false })
+      plugin.off('newState', this.toggleOff)
+    }
+  }
+
+  handleSwitch = plugin => {
+    const { handleToggle } = this.props
+    this.setState({ isToggled: true }, () => {
+      plugin.on('newState', this.toggleOff(plugin))
+    })
+    handleToggle(plugin)
+  }
+
   render() {
+    const { isToggled } = this.state
     const {
       classes,
-      handleToggle,
       handleSelectPlugin,
       isRunning,
       isSelected,
@@ -85,8 +104,9 @@ class PluginsNavListItem extends Component {
           <span>
             <Switch
               color="primary"
-              onChange={() => handleToggle(plugin)}
+              onChange={() => this.handleSwitch(plugin)}
               checked={isRunning}
+              disabled={isToggled}
               data-test-id={`switch-${plugin.name}`}
             />
           </span>

--- a/src/components/Plugins/PluginsNavListItem.js
+++ b/src/components/Plugins/PluginsNavListItem.js
@@ -47,7 +47,7 @@ class PluginsNavListItem extends Component {
   }
 
   toggleOff = plugin => newState => {
-    if (['started', 'connected', 'stopped'].includes(newState)) {
+    if (['started', 'connected', 'stopped', 'error'].includes(newState)) {
       this.setState({ isToggled: false })
       plugin.off('newState', this.toggleOff)
     }

--- a/src/components/Plugins/index.js
+++ b/src/components/Plugins/index.js
@@ -88,7 +88,9 @@ class PluginsTab extends Component {
 
   handleToggle = plugin => {
     const { pluginState, dispatch } = this.props
-    // TODO: refactor to only require pluginName to toggle?
+    // TODO: refactor to only require pluginName to toggle,
+    // then function can be placed in PlguinsNavListItem.js
+    // instead of needing to be passed through props.
     dispatch(togglePlugin(plugin, pluginState[plugin.name].release))
   }
 


### PR DESCRIPTION
#### What does it do?
This is an initial experimental stab at fixing https://github.com/ethereum/grid/issues/515, please let me know what you think. It disables the switch on click until it gets a `started` event (for switching on) and `stopped` event (for switching off).

If we like the logic / UX, then I can port it over to nano as well.

#### Gifs
Example 1 (release already downloaded):
![geth toggle](https://user-images.githubusercontent.com/22116/68827738-e6a95580-0657-11ea-9d14-44544f569cd6.gif)

Example 2 (release to one-click download): 
![geth toggle dl](https://user-images.githubusercontent.com/22116/68827773-080a4180-0658-11ea-849f-61d38558ed2e.gif)
