### PR TITLE
fix: lowercase v in displayVersion

### DIFF
--- a/src/components/Plugins/PluginConfig/VersionList/VersionListItem.js
+++ b/src/components/Plugins/PluginConfig/VersionList/VersionListItem.js
@@ -45,10 +45,14 @@ export default class VersionListItem extends Component {
     let metadata
     if (!platform) {
       metadata = ''
-    } else if (!arch) {
-      metadata = ` - ${platform}`
     } else {
-      metadata = ` - ${platform} (${arch})`
+      const platformCapitalized =
+        platform.charAt(0).toUpperCase() + platform.slice(1)
+      if (!arch) {
+        metadata = ` - ${platformCapitalized}`
+      } else {
+        metadata = ` - ${platformCapitalized} (${arch})`
+      }
     }
 
     return `${displayName} ${displayVersion}${metadata}`
@@ -202,7 +206,6 @@ const ListItemTextVersion = styled(({ isLocalRelease, children, ...rest }) => (
     {children}
   </ListItemText>
 ))`
-  text-transform: capitalize;
   ${props =>
     props.isLocalRelease &&
     css`


### PR DESCRIPTION
#### What does it do?
Makes the `v` lowercase in release version titles

<img width="1212" alt="Screen Shot 2019-11-13 at 9 14 19 PM" src="https://user-images.githubusercontent.com/22116/68828518-c9c25180-065a-11ea-88b7-8e16809a1d07.png">

Fixes nitpick in https://github.com/ethereum/grid/issues/512